### PR TITLE
Provide hints about how to handle InexactErrors during saving

### DIFF
--- a/src/ImageMagick.jl
+++ b/src/ImageMagick.jl
@@ -148,7 +148,13 @@ function save_(filename::AbstractString, img, permute_horizontal=true; mapi = ma
 end
 
 function image2wand(img, mapi, quality, permute_horizontal=true)
-    imgw = map(mapi, img)
+    local imgw
+    try
+        imgw = map(mapi, img)
+    catch
+        warn("Mapping to the storage type failed; perhaps your data had out-of-range values?\nTry `map(Images.Clamp01NaN(img), img)` to clamp values to a valid range.")
+        rethrow()
+    end
     permute_horizontal && (imgw = permutedims_horizontal(imgw))
     have_color = colordim(imgw)!=0
     if ndims(imgw) > 3+have_color


### PR DESCRIPTION
Currently we have this:

``` jl
julia> A = [-1.0 0.0; 0.5 1.0]
2x2 Array{Float64,2}:
 -1.0  0.0
  0.5  1.0

julia> using FileIO

julia> save("/tmp/test.png", A)
WARNING: InexactError()
 in trunc at float.jl:357
 in _map_a! at /home/tim/.julia/v0.4/Images/src/map.jl:489
 in image2wand at /home/tim/.julia/v0.4/ImageMagick/src/ImageMagick.jl:151
 in save_ at /home/tim/.julia/v0.4/ImageMagick/src/ImageMagick.jl:146
 in save at /home/tim/.julia/v0.4/ImageMagick/src/ImageMagick.jl:64
 in save at /home/tim/.julia/v0.4/FileIO/src/loadsave.jl:92
 in save at /home/tim/.julia/v0.4/FileIO/src/loadsave.jl:51
```

which is pretty cryptic (see https://github.com/timholy/Images.jl/issues/422).

This adds a helpful hint:

``` jl
WARNING: Mapping to the storage type failed; perhaps your data had out-of-range values?
Try `map(Images.Clamp01NaN(img), img)` to clamp values to a valid range.
```

It's a little verbose to include the module name, but if people are working with plain arrays then I was concerned that `Clamp01NaN` might not be in-scope.

What do you think, @xanderdunn?
