### PR TITLE
Finish write-to-stream

### DIFF
--- a/src/ImageMagick.jl
+++ b/src/ImageMagick.jl
@@ -64,7 +64,7 @@ load{T <: DataFormat}(image::File{T}, args...; key_args...) = load_(filename(ima
 save{T <: DataFormat}(image::File{T}, args...; key_args...) = save_(filename(image), args...; key_args...)
 
 load{T <: DataFormat}(image::Stream{T}, args...; key_args...) = load_(stream(image), args...; key_args...)
-save{T <: DataFormat}(image::Stream{T}, args...; key_args...) = save_(stream(image), args...; key_args...)
+save{T <: DataFormat}(image::Stream{T}, args...; key_args...) = save_(image, args...; key_args...)
 
 const ufixedtype = Dict(10=>UFixed10, 12=>UFixed12, 14=>UFixed14, 16=>UFixed16)
 
@@ -147,6 +147,12 @@ function save_(filename::AbstractString, img, permute_horizontal=true; mapi = ma
     writeimage(wand, filename)
 end
 
+function save_(s::Stream, img, permute_horizontal=true; mapi = Images.mapinfo_writemime(img), quality = nothing)
+    wand = image2wand(img, mapi, quality, permute_horizontal)
+    blob = getblob(wand, formatstring(s))
+    write(stream(s), blob)
+end
+
 function image2wand(img, mapi, quality, permute_horizontal=true)
     local imgw
     try
@@ -185,6 +191,8 @@ function image2wand(img, mapi, quality, permute_horizontal=true)
     resetiterator(wand)
     wand
 end
+
+formatstring{S}(s::Stream{DataFormat{S}}) = string(S)
 
 # ImageMagick mapinfo client. Converts to RGB and uses UFixed.
 mapinfo{T<:UFixed}(img::AbstractArray{T}) = MapNone{T}()

--- a/src/libmagickwand.jl
+++ b/src/libmagickwand.jl
@@ -247,6 +247,12 @@ function writeimage(wand::MagickWand, filename::AbstractString)
     nothing
 end
 
+function writeimage(wand::MagickWand, stream::IO)
+    status = ccall((:MagickWriteImageFile, libwand), Cint, (Ptr{Void}, Ptr{Void}), wand.ptr, Libc.FILE(stream))
+    status == 0 && error(wand)
+    nothing
+end
+
 function size(wand::MagickWand)
     height = ccall((:MagickGetImageHeight, libwand), Csize_t, (Ptr{Void},), wand.ptr)
     width = ccall((:MagickGetImageWidth, libwand), Csize_t, (Ptr{Void},), wand.ptr)

--- a/src/libmagickwand.jl
+++ b/src/libmagickwand.jl
@@ -247,12 +247,6 @@ function writeimage(wand::MagickWand, filename::AbstractString)
     nothing
 end
 
-function writeimage(wand::MagickWand, stream::IO)
-    status = ccall((:MagickWriteImageFile, libwand), Cint, (Ptr{Void}, Ptr{Void}), wand.ptr, Libc.FILE(stream))
-    status == 0 && error(wand)
-    nothing
-end
-
 function size(wand::MagickWand)
     height = ccall((:MagickGetImageHeight, libwand), Csize_t, (Ptr{Void},), wand.ptr)
     width = ccall((:MagickGetImageWidth, libwand), Csize_t, (Ptr{Void},), wand.ptr)

--- a/test/constructed_images.jl
+++ b/test/constructed_images.jl
@@ -133,6 +133,19 @@ facts("IO") do
         close(io)
     end
 
+    @unix_only context("Writing to a stream (PR #22)") do
+        wand = ImageMagick.MagickWand()
+        ImageMagick.readimage(wand, joinpath(workdir, "2by2.png"))
+        ImageMagick.setimageformat(wand, "png")
+        fn = joinpath(workdir, "2by2_fromstream.png")
+        open(fn, "w") do f
+            ImageMagick.writeimage(wand, f)
+        end
+        img = load(fn)
+        orig_img = load(joinpath(workdir, "2by2.png"))
+        @fact img --> orig_img
+    end
+
     @unix_only context("Reading from a byte array (issue #279)") do
         fn = joinpath(workdir, "2by2.png")
         io = open(fn)

--- a/test/constructed_images.jl
+++ b/test/constructed_images.jl
@@ -127,22 +127,19 @@ facts("IO") do
 
     @unix_only context("Reading from a stream (issue #312)") do
         fn = joinpath(workdir, "2by2.png")
-        io = open(fn)
-        img = load(io)
+        img = open(fn) do io
+            load(io)
+        end
         @fact isa(img, Images.Image) --> true
-        close(io)
     end
 
     @unix_only context("Writing to a stream (PR #22)") do
-        wand = ImageMagick.MagickWand()
-        ImageMagick.readimage(wand, joinpath(workdir, "2by2.png"))
-        ImageMagick.setimageformat(wand, "png")
+        orig_img = load(joinpath(workdir, "2by2.png"))
         fn = joinpath(workdir, "2by2_fromstream.png")
         open(fn, "w") do f
-            ImageMagick.writeimage(wand, f)
+            save(Stream(format"PNG", f), orig_img)
         end
         img = load(fn)
-        orig_img = load(joinpath(workdir, "2by2.png"))
         @fact img --> orig_img
     end
 

--- a/test/readremote.jl
+++ b/test/readremote.jl
@@ -76,9 +76,6 @@ facts("Read remote") do
         save(outname, img)
         imgc = load(outname)
         T = eltype(imgc)
-        lim = limits(imgc)
-        @fact typeof(lim[1]) --> typeof(lim[2])  # issue #62
-        @fact typeof(lim[2]) --> T  # issue #62
         # Why does this one fail on OSX??
         @osx? nothing : @fact img.data --> imgc.data
         @fact reinterpret(UInt32, data(map(mapinfo(RGB24, img), img))) -->


### PR DESCRIPTION
This incorporates #22, hopefully fixing the problems that caused Travis errors (julia-0.5 is failing for reasons this doesn't address, but Travis and I were both getting failures on Linux with julia-0.4). With this version, it should be called as `save(Stream(format"PNG", io), img)`. CC @spencerlyon2.
