### PR TITLE
Check exif orientation and adjust spatialorder to match (partial)

### DIFF
--- a/src/ImageMagick.jl
+++ b/src/ImageMagick.jl
@@ -127,7 +127,13 @@ function load_(file::Union{AbstractString,IO,Vector{UInt8}}; ImageType=Image, ex
     exportimagepixels!(buf, wand, cs, channelorder)
 
     prop = Dict{UTF8String, Any}()
-    prop["spatialorder"] = ["x", "y"]
+    orient = getimageproperty(wand, "exif:Orientation", false)
+    if haskey(orientation_dict, orient)
+        prop["spatialorder"] = orientation_dict[orient]
+    else
+        warn("orientation $orient not yet supported")
+        prop["spatialorder"] = ["x", "y"]
+    end
     n > 1 && (prop["timedim"] = ndims(buf))
     prop["colorspace"] = cs
 

--- a/src/ImageMagick.jl
+++ b/src/ImageMagick.jl
@@ -2,7 +2,7 @@ __precompile__(true)
 module ImageMagick
 
 using FixedPointNumbers, ColorTypes, Images, ColorVectorSpace
-import FileIO: DataFormat, @format_str, Stream, File, filename, stream
+using FileIO: DataFormat, @format_str, Stream, File, filename, stream
 
 export MagickWand
 export constituteimage
@@ -60,11 +60,14 @@ image_formats = [
     format"TGA"
 ]
 
-load{T <: DataFormat}(image::File{T}, args...; key_args...) = load_(filename(image), args...; key_args...)
-save{T <: DataFormat}(image::File{T}, args...; key_args...) = save_(filename(image), args...; key_args...)
+load{T <: DataFormat}(imagefile::File{T}, args...; key_args...) = load_(filename(imagefile), args...; key_args...)
+load(filename::AbstractString, args...; key_args...) = load_(filename, args...; key_args...)
+save{T <: DataFormat}(imagefile::File{T}, args...; key_args...) = save_(filename(imagefile), args...; key_args...)
+save(filename::AbstractString, args...; key_args...) = save_(filename, args...; key_args...)
 
-load{T <: DataFormat}(image::Stream{T}, args...; key_args...) = load_(stream(image), args...; key_args...)
-save{T <: DataFormat}(image::Stream{T}, args...; key_args...) = save_(image, args...; key_args...)
+load{T <: DataFormat}(imgstream::Stream{T}, args...; key_args...) = load_(stream(imgstream), args...; key_args...)
+load(imgstream::IO, args...; key_args...) = load_(imgstream, args...; key_args...)
+save{T <: DataFormat}(imgstream::Stream{T}, args...; key_args...) = save_(imgstream, args...; key_args...)
 
 const ufixedtype = Dict(10=>UFixed10, 12=>UFixed12, 14=>UFixed14, 16=>UFixed16)
 

--- a/src/libmagickwand.jl
+++ b/src/libmagickwand.jl
@@ -99,6 +99,10 @@ for AC in vcat(subtypes(AlphaColor), subtypes(ColorAlpha))
     end
 end
 
+orientation_dict = Dict(nothing => ["x", "y"],
+                        "1" => ["x", "y"],
+                        "5" => ["y", "x"])
+
 function nchannels(imtype::AbstractString, cs::AbstractString, havealpha = false)
     n = 3
     if startswith(imtype, "Grayscale") || startswith(imtype, "Bilevel")
@@ -281,11 +285,13 @@ function getimageproperties(wand::MagickWand,patt::AbstractString)
     end
 end
 
-function getimageproperty(wand::MagickWand,prop::AbstractString)
+function getimageproperty(wand::MagickWand, prop::AbstractString, warnuser::Bool=true)
     p = ccall((:MagickGetImageProperty, libwand),Ptr{UInt8},(Ptr{Void},Ptr{UInt8}),wand.ptr,prop)
     if p == convert(Ptr{UInt8}, C_NULL)
-        possib = getimageproperties(wand,"*")
-        warn("Undefined property, possible names are \"$(join(possib,"\",\""))\"")
+        if warnuser
+            possib = getimageproperties(wand,"*")
+            warn("Undefined property, possible names are \"$(join(possib,"\",\""))\"")
+        end
         nothing
     else
         bytestring(p)

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,1 +1,2 @@
 FactCheck
+ZipFile

--- a/test/constructed_images.jl
+++ b/test/constructed_images.jl
@@ -11,23 +11,23 @@ facts("IO") do
     context("Binary png") do
         a = rand(Bool,5,5)
         fn = joinpath(workdir, "5by5.png")
-        save(fn, a)
-        b = load(fn)
+        ImageMagick.save(fn, a)
+        b = ImageMagick.load(fn)
         a8 = convert(Array{Gray{UFixed8}}, a) # IM won't read back as Bool
         @fact convert(Array, b) --> a8
         aim = grayim(a)
-        save(fn, aim)
-        b = load(fn)
+        ImageMagick.save(fn, aim)
+        b = ImageMagick.load(fn)
         @fact b --> copyproperties(aim, a8)
         a = bitrand(5,5)
         fn = joinpath(workdir, "5by5.png")
-        save(fn, a)
-        b = load(fn)
+        ImageMagick.save(fn, a)
+        b = ImageMagick.load(fn)
         a8 = convert(Array{Gray{UFixed8}}, a)
         @fact convert(Array, b) --> a8
         aim = grayim(a)
-        save(fn, aim)
-        b = load(fn)
+        ImageMagick.save(fn, aim)
+        b = ImageMagick.load(fn)
         @fact b --> copyproperties(aim, a8)
     end
 
@@ -36,24 +36,24 @@ facts("IO") do
         a[1,1] = 1
         aa = convert(Array{UFixed8}, a)
         fn = joinpath(workdir, "2by2.png")
-        save(fn, a)
-        b = load(fn)
+        ImageMagick.save(fn, a)
+        b = ImageMagick.load(fn)
         @fact convert(Array, b) --> aa
-        save(fn, aa)
-        b = load(fn)
+        ImageMagick.save(fn, aa)
+        b = ImageMagick.load(fn)
         @fact convert(Array, b) --> aa
         open(fn, "w") do io
             writemime(io, MIME("image/png"), b; minpixels=0)
         end
-        bb = load(fn)
+        bb = ImageMagick.load(fn)
         @fact bb.data --> b.data
         aaimg = Images.grayim(aa)
-        save(fn, aaimg)
-        b = load(fn)
+        ImageMagick.save(fn, aaimg)
+        b = ImageMagick.load(fn)
         @fact b --> aaimg
         aa = convert(Array{UFixed16}, a)
-        save(fn, aa)
-        b = load(fn)
+        ImageMagick.save(fn, aa)
+        b = ImageMagick.load(fn)
         @fact convert(Array, b) --> aa
     end
 
@@ -63,15 +63,15 @@ facts("IO") do
         A[1] = 1
         img = Images.colorim(A)
         img24 = convert(Images.Image{RGB24}, img)
-        save(fn, img24)
-        b = load(fn)
+        ImageMagick.save(fn, img24)
+        b = ImageMagick.load(fn)
         imgrgb8 = convert(Images.Image{RGB{UFixed8}}, img)
         @fact Images.data(imgrgb8) --> Images.data(b)
 
         open(fn, "w") do io
             writemime(io, MIME("image/png"), imgrgb8; minpixels=0)
         end
-        bb = load(fn)
+        bb = ImageMagick.load(fn)
         @fact data(bb) --> data(imgrgb8)
     end
 
@@ -87,34 +87,34 @@ facts("IO") do
         cmaprgb[1:128] = [(1-x)*b + x*w for x in f]
         cmaprgb[129:end] = [(1-x)*w + x*r for x in f[2:end]]
         img = Images.ImageCmap(dataint, cmaprgb)
-        save(joinpath(workdir,"cmap.jpg"), img)
+        ImageMagick.save(joinpath(workdir,"cmap.jpg"), img)
         cmaprgb = Array(RGB, 255) # poorly-typed cmap, issue #336
         cmaprgb[1:128] = [(1-x)*b + x*w for x in f]
         cmaprgb[129:end] = [(1-x)*w + x*r for x in f[2:end]]
         img = Images.ImageCmap(dataint, cmaprgb)
-        save(joinpath(workdir, "cmap.png"), img)
+        ImageMagick.save(joinpath(workdir, "cmap.png"), img)
     end
 
     context("Alpha") do
         c = reinterpret(Images.BGRA{UFixed8}, [0xf0884422]'')
         fn = joinpath(workdir, "alpha.png")
-    	save(fn, c)
-        C = load(fn)
+    	ImageMagick.save(fn, c)
+        C = ImageMagick.load(fn)
         if !ontravis
             # disabled on Travis because it has a weird, old copy of
             # ImageMagick for which this fails (see Images#261)
             @fact C[1] --> c[1]
         end
-        save(fn, reinterpret(ARGB32, [0xf0884422]''))
-        D = load(fn)
+        ImageMagick.save(fn, reinterpret(ARGB32, [0xf0884422]''))
+        D = ImageMagick.load(fn)
         if !ontravis
             @fact D[1] --> c[1]
         end
 
         # Images#396
         c = colorim(rand(UInt8, 2, 2, 4), "RGBA")
-        save(fn, c)
-        D = load(fn)
+        ImageMagick.save(fn, c)
+        D = ImageMagick.load(fn)
         C = permutedims(convert(Image{eltype(D)}, c), spatialorder(D))
         if !ontravis
             for i = 1:length(D)
@@ -128,8 +128,8 @@ facts("IO") do
         Ar[1] = 0xff
         A = Image(map(x->Gray(UFixed8(x,0)), Ar); colorspace="Gray", spatialorder=["x", "y"], timedim=3) # grayim does not use timedim, but load does...
         fn = joinpath(workdir, "3d.tif")
-        save(fn, A)
-        B = load(fn)
+        ImageMagick.save(fn, A)
+        B = ImageMagick.load(fn)
 
         @fact A --> B
     end
@@ -141,9 +141,9 @@ facts("IO") do
         A[1,1] = -0.4
         fn = joinpath(workdir, "2by2.png")
         println("The following InexactError is a sign of normal operation:")
-        @fact_throws InexactError save(fn, A)
-        save(fn, A, mapi=mapinfo(Images.Clamp, A))
-        B = load(fn)
+        @fact_throws InexactError ImageMagick.save(fn, A)
+        ImageMagick.save(fn, A, mapi=mapinfo(Images.Clamp, A))
+        B = ImageMagick.load(fn)
         A[1,1] = 0
         @fact B --> map(Gray{UFixed8}, A)
     end
@@ -151,18 +151,18 @@ facts("IO") do
     @unix_only context("Reading from a stream (issue #312)") do
         fn = joinpath(workdir, "2by2.png")
         img = open(fn) do io
-            load(io)
+            ImageMagick.load(io)
         end
         @fact isa(img, Images.Image) --> true
     end
 
     @unix_only context("Writing to a stream (PR #22)") do
-        orig_img = load(joinpath(workdir, "2by2.png"))
+        orig_img = ImageMagick.load(joinpath(workdir, "2by2.png"))
         fn = joinpath(workdir, "2by2_fromstream.png")
         open(fn, "w") do f
-            save(Stream(format"PNG", f), orig_img)
+            ImageMagick.save(Stream(format"PNG", f), orig_img)
         end
-        img = load(fn)
+        img = ImageMagick.load(fn)
         @fact img --> orig_img
     end
 
@@ -183,7 +183,7 @@ facts("IO") do
         open(fn, "w") do file
             writemime(file, MIME("image/png"), a, minpixels=0)
         end
-        b = load(fn)
+        b = ImageMagick.load(fn)
         @fact data(b) --> data(a)
 
         Ar = rand(UInt8, 3, 1021, 1026)
@@ -193,7 +193,7 @@ facts("IO") do
         open(fn, "w") do file
             writemime(file, MIME("image/png"), abig, maxpixels=10^6)
         end
-        b = load(fn)
+        b = ImageMagick.load(fn)
         @fact data(b) --> convert(Array{RGB{UFixed8},2}, data(restrict(abig, (1,2))))
 
         # Issue #269
@@ -203,7 +203,7 @@ facts("IO") do
         open(fn, "w") do file
             writemime(file, MIME("image/png"), abig, maxpixels=10^6)
         end
-        b = load(fn)
+        b = ImageMagick.load(fn)
         @fact data(b) --> convert(Array{RGB{UFixed8},2}, data(restrict(abig, (1,2))))
     end
 

--- a/test/readremote.jl
+++ b/test/readremote.jl
@@ -22,14 +22,14 @@ facts("Read remote") do
 
     context("Gray") do
         file = getfile("jigsaw_tmpl.png")
-        img = load(file)
+        img = ImageMagick.load(file)
         @fact colorspace(img) --> "Gray"
         @fact ndims(img) --> 2
         @fact colordim(img) --> 0
         @fact eltype(img) --> Gray{UFixed8}
         outname = joinpath(writedir, "jigsaw_tmpl.png")
-        save(outname, img)
-        imgc = load(outname)
+        ImageMagick.save(outname, img)
+        imgc = ImageMagick.load(outname)
         @fact img.data --> imgc.data
         @fact reinterpret(UInt32, data(map(mapinfo(RGB24, img), img))) -->
             map(x->x&0x00ffffff, reinterpret(UInt32, data(map(mapinfo(ARGB32, img), img))))
@@ -45,16 +45,16 @@ facts("Read remote") do
 
     context("Gray with alpha channel") do
         file = getfile("wmark_image.png")
-        img = load(file)
+        img = ImageMagick.load(file)
         @fact colorspace(img) --> "GrayA"
         @fact ndims(img) --> 2
         @fact colordim(img) --> 0
         @fact eltype(img) --> Images.ColorTypes.GrayA{UFixed8}
         @linux_only begin
             outname = joinpath(writedir, "wmark_image.png")
-            save(outname, img)
+            ImageMagick.save(outname, img)
             sleep(0.2)
-            imgc = load(outname)
+            imgc = ImageMagick.load(outname)
             @fact img.data --> imgc.data
             open(outname, "w") do file
                 writemime(file, "image/png", img)
@@ -67,15 +67,15 @@ facts("Read remote") do
 
     context("RGB") do
         file = getfile("rose.png")
-        img = load(file)
+        img = ImageMagick.load(file)
         # Mac reader reports RGB4, imagemagick reports RGB
         @fact colorspace(img) --> "RGB"
         @fact ndims(img) --> 2
         @fact colordim(img) --> 0
         @fact eltype(img) --> RGB{UFixed8}
         outname = joinpath(writedir, "rose.tiff")
-        save(outname, img)
-        imgc = load(outname)
+        ImageMagick.save(outname, img)
+        imgc = ImageMagick.load(outname)
         T = eltype(imgc)
         # Why does this one fail on OSX??
         @osx? nothing : @fact img.data --> imgc.data
@@ -118,16 +118,16 @@ facts("Read remote") do
 
     context("RGBA with 16 bit depth") do
         file = getfile("autumn_leaves.png")
-        img = load(file)
+        img = ImageMagick.load(file)
         @fact colorspace(img) --> "BGRA"
         @fact ndims(img) --> 2
         @fact colordim(img) --> 0
         @fact eltype(img) --> Images.ColorTypes.BGRA{UFixed16}
         outname = joinpath(writedir, "autumn_leaves.png")
         @osx? nothing : begin
-            save(outname, img)
+            ImageMagick.save(outname, img)
             sleep(0.2)
-            imgc = load(outname)
+            imgc = ImageMagick.load(outname)
             @fact img.data --> imgc.data
             @fact reinterpret(UInt32, data(map(mapinfo(RGB24, img), img))) -->
                 map(x->x&0x00ffffff, reinterpret(UInt32, data(map(mapinfo(ARGB32, img), img))))
@@ -140,7 +140,7 @@ facts("Read remote") do
 
     context("Indexed") do
         file = getfile("present.gif")
-        img = load(file)
+        img = ImageMagick.load(file)
         @fact nimages(img) --> 1
         @fact reinterpret(UInt32, data(map(mapinfo(RGB24, img), img))) -->
             map(x->x&0x00ffffff, reinterpret(UInt32, data(map(mapinfo(ARGB32, img), img))))
@@ -155,12 +155,12 @@ facts("Read remote") do
         fname = "swirl_video.gif"
         #fname = "bunny_anim.gif"  # this one has transparency but LibMagick gets confused about its size
         file = getfile(fname)  # this also has transparency
-        img = load(file)
+        img = ImageMagick.load(file)
         @fact timedim(img) --> 3
         @fact nimages(img) --> 26
         outname = joinpath(writedir, fname)
-        save(outname, img)
-        imgc = load(outname)
+        ImageMagick.save(outname, img)
+        imgc = ImageMagick.load(outname)
         # Something weird happens after the 2nd image (compression?), and one starts getting subtle differences.
         # So don't compare the values.
         # Also take the opportunity to test some things with temporal images
@@ -180,21 +180,21 @@ facts("Read remote") do
         @osx? nothing : begin
             file = getfile("autumn_leaves.png")
             # List properties
-            extraProps = load(file, extrapropertynames=true)
+            extraProps = ImageMagick.load(file, extrapropertynames=true)
 
-            img = load(file,extraprop=extraProps)
+            img = ImageMagick.load(file,extraprop=extraProps)
             props = properties(img)
             for key in extraProps
                 @fact haskey(props, key) --> true
                 @fact props[key] --> not(nothing)
             end
-            img = load(file, extraprop=extraProps[1])
+            img = ImageMagick.load(file, extraprop=extraProps[1])
             props = properties(img)
             @fact haskey(props, extraProps[1]) --> true
             @fact props[extraProps[1]] --> not(nothing)
 
             println("The following \"Undefined property\" warning indicates normal operation")
-            img = load(file, extraprop="Non existing property")
+            img = ImageMagick.load(file, extraprop="Non existing property")
             props = properties(img)
             @fact haskey(props, "Non existing property") --> true
             @fact props["Non existing property"] --> nothing


### PR DESCRIPTION
Partially addresses http://stackoverflow.com/questions/35757189/distinguish-vertical-and-horizontal-format-image-with-julia.

This doesn't solve the full orientation problem because of the possibility of coordinate flips; as it is, we can support only 2 of the 8 possibilities. When I have a couple of spare weeks, I want to rebase Images on https://github.com/mbauman/AxisArrays.jl (hopefully this will be the final low-level restructuring!), and then we can support the full range of possibilities.

CC @mbauman (simply for interest).
