### PR TITLE
DL_LOAD_PATH not exported from Base anymore

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -4,11 +4,6 @@ import Compat.String
 
 @BinDeps.setup
 
-mpath = get(ENV, "MAGICK_HOME", "") # If MAGICK_HOME is defined, add to library search path
-if !isempty(mpath)
-    push!(DL_LOAD_PATH, mpath)
-    push!(DL_LOAD_PATH, joinpath(mpath,"lib"))
-end
 libnames    = ["libMagickWand", "CORE_RL_wand_"]
 suffixes    = ["", "-Q16", "-6.Q16", "-Q8"]
 options     = ["", "HDRI"]
@@ -21,6 +16,12 @@ function init_deps()
     ccall((:MagickWandGenesis,libwand), Void, ())
 end
 """
+
+mpath = get(ENV, "MAGICK_HOME", "") # If MAGICK_HOME is defined, add to library search path
+if !isempty(mpath)
+    provides(Binaries, mpath, libwand)
+    provides(Binaries, joinpath(mpath,"lib"), libwand)
+end
 
 @linux_only begin
     kwargs = Any[(:onload, initfun)]


### PR DESCRIPTION
`Pkg.build("ImageMagick")` throws an error if `ENV["MAGICK_HOME"]` is set.  this minimal change will fix that.

however, i'd like to ask how best to resolve choosing between multiple installations of ImageMagick.  my system comes with `/usr/lib64/libMagickWans.so.2`, which is version 6.5.4.  only version 6.7+ however supports 3D TIFs (see https://github.com/JuliaIO/FileIO.jl/issues/57).  so i installed a new version in `$HOME/local`, and exported `MAGICK_HOME` appropriately.  `build.jl` did not find the new one of course, unless i changed the order of suffixes and extensions to:

```
suffixes    = ["-6.Q16", "", "-Q16", "-Q8"]
extensions  = [".so.2", "", ".so.4", ".so.5"]
```

what's the better way that would work for everyone?
