### PR TITLE
add writeimage(::MagickWand, ::IO)

### DIFF
--- a/src/libmagickwand.jl
+++ b/src/libmagickwand.jl
@@ -251,6 +251,12 @@ function writeimage(wand::MagickWand, filename::AbstractString)
     nothing
 end
 
+function writeimage(wand::MagickWand, stream::IO)
+    status = ccall((:MagickWriteImagesFile, libwand), Cint, (Ptr{Void}, Ptr{Void}), wand.ptr, Libc.FILE(stream).ptr)
+    status == 0 && error(wand)
+    nothing
+end
+
 function size(wand::MagickWand)
     height = ccall((:MagickGetImageHeight, libwand), Csize_t, (Ptr{Void},), wand.ptr)
     width = ccall((:MagickGetImageWidth, libwand), Csize_t, (Ptr{Void},), wand.ptr)


### PR DESCRIPTION
This resolves an issue when attempting to save a png using the PlotlyJS backend in Plots.  The command:

``` julia
julia> using Plots; plotlyjs(); p = plot(rand(10));
[Plots.jl] Initializing backend: plotlyjs

julia> png("/tmp/tmp")
```

would previously fail with:

```
ERROR: MethodError: `writeimage` has no method matching writeimage(::ImageMagick.MagickWand, ::IOStream)
Closest candidates are:
  writeimage(::ImageMagick.MagickWand, ::AbstractString)
 in writemime at /home/tom/.julia/v0.4/PlotlyJS/src/savefig.jl:185
```
