### PR TITLE
WIP (do not merge): decouple ImageMagick from Images, decouple load from properties, better orientation handling

### DIFF
--- a/src/ImageMagick.jl
+++ b/src/ImageMagick.jl
@@ -76,14 +76,11 @@ const ufixedtype = Dict(10=>UFixed10, 12=>UFixed12, 14=>UFixed14, 16=>UFixed16)
 
 readblob(data::Vector{UInt8}) = load_(data)
 
-function load_(file::Union{AbstractString,IO,Vector{UInt8}}; ImageType=Image, extraprop="", extrapropertynames=false)
+function load_(file::Union{AbstractString,IO,Vector{UInt8}})
+    # TODO: deprecate ImageType kw, extraprop, extrapropertynames
     wand = MagickWand()
     readimage(wand, file)
     resetiterator(wand)
-
-    if extrapropertynames
-        return(getimageproperties(wand, "*"))
-    end
 
     # Determine what we need to know about the image format
     sz = size(wand)
@@ -134,22 +131,9 @@ function load_(file::Union{AbstractString,IO,Vector{UInt8}}; ImageType=Image, ex
 
     prop = Dict{Compat.UTF8String, Any}()
     orient = getimageproperty(wand, "exif:Orientation", false)
-    if haskey(orientation_dict, orient)
-        prop["spatialorder"] = orientation_dict[orient]
-    else
-        warn("orientation $orient not yet supported")
-        prop["spatialorder"] = ["x", "y"]
-    end
-    n > 1 && (prop["timedim"] = ndims(buf))
-    prop["colorspace"] = cs
+    img = orientation_dict[orient](buf)
 
-    if extraprop != ""
-        for extra in [extraprop;]
-            prop[extra] = getimageproperty(wand,extra)
-        end
-    end
-
-    ImageType(buf, prop)
+    img
 end
 
 

--- a/src/libmagickwand.jl
+++ b/src/libmagickwand.jl
@@ -105,12 +105,12 @@ flip12(A) = sub(A, reverse(1:size(A, 1)), reverse(1:size(A, 2)))
 orientation_dict = Dict(nothing => identity,
                         "1" => identity,
                         "2" => flip1,
-                        "3" => flip2,
-                        "4" => flip12,
+                        "3" => flip12, #flip2,
+                        "4" => flip2,
                         "5" => A->PermutedDimsArrays.PermutedDimsArray(A, [2,1]),
-                        "6" => A->PermutedDimsArrays.PermutedDimsArray(flip1(A), [2,1]),
-                        "7" => A->PermutedDimsArrays.PermutedDimsArray(flip2(A), [2,1]),
-                        "8" => A->PermutedDimsArrays.PermutedDimsArray(flip12(A), [2,1]))
+                        "6" => A->PermutedDimsArrays.PermutedDimsArray(flip2(A), [2,1]),
+                        "7" => A->PermutedDimsArrays.PermutedDimsArray(flip12(A), [2,1]),
+                        "8" => A->PermutedDimsArrays.PermutedDimsArray(flip1(A), [2,1]))
 
 function nchannels(imtype::AbstractString, cs::AbstractString, havealpha = false)
     n = 3

--- a/src/libmagickwand.jl
+++ b/src/libmagickwand.jl
@@ -1,4 +1,4 @@
-import Base: error, size
+import Base: error, size, PermutedDimsArrays
 
 export MagickWand,
     constituteimage,
@@ -107,10 +107,10 @@ orientation_dict = Dict(nothing => identity,
                         "2" => flip1,
                         "3" => flip2,
                         "4" => flip12,
-                        "5" => A->PermutedDimsArray(A, [2,1]),
-                        "6" => A->PermutedDimsArray(flip1(A), [2,1]),
-                        "7" => A->PermutedDimsArray(flip2(A), [2,1]),
-                        "8" => PermutedDimsArray(flip12(A), [2,1]))
+                        "5" => A->PermutedDimsArrays.PermutedDimsArray(A, [2,1]),
+                        "6" => A->PermutedDimsArrays.PermutedDimsArray(flip1(A), [2,1]),
+                        "7" => A->PermutedDimsArrays.PermutedDimsArray(flip2(A), [2,1]),
+                        "8" => A->PermutedDimsArrays.PermutedDimsArray(flip12(A), [2,1]))
 
 function nchannels(imtype::AbstractString, cs::AbstractString, havealpha = false)
     n = 3

--- a/src/libmagickwand.jl
+++ b/src/libmagickwand.jl
@@ -98,9 +98,19 @@ for AC in vcat(subtypes(AlphaColor), subtypes(ColorAlpha))
     end
 end
 
-orientation_dict = Dict(nothing => ["x", "y"],
-                        "1" => ["x", "y"],
-                        "5" => ["y", "x"])
+flip1(A) = sub(A, reverse(1:size(A, 1)), 1:size(A, 2))
+flip2(A) = sub(A, 1:size(A, 1), reverse(1:size(A, 2)))
+flip12(A) = sub(A, reverse(1:size(A, 1)), reverse(1:size(A, 2)))
+
+orientation_dict = Dict(nothing => identity,
+                        "1" => identity,
+                        "2" => flip1,
+                        "3" => flip2,
+                        "4" => flip12,
+                        "5" => A->PermutedDimsArray(A, [2,1]),
+                        "6" => A->PermutedDimsArray(flip1(A), [2,1]),
+                        "7" => A->PermutedDimsArray(flip2(A), [2,1]),
+                        "8" => PermutedDimsArray(flip12(A), [2,1]))
 
 function nchannels(imtype::AbstractString, cs::AbstractString, havealpha = false)
     n = 3

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,2 +1,3 @@
+julia 0.5-
 FactCheck
 ZipFile

--- a/test/readremote.jl
+++ b/test/readremote.jl
@@ -204,22 +204,20 @@ facts("Read remote") do
 end
 
 facts("EXIF orientation") do
-    function test_orientation(r, odict)
-        for f in r.files
-            bn = basename(f.name)
-            if haskey(odict, bn)
-                so = odict[bn]
-                data = read(f, UInt8, f.uncompressedsize)
-                img = readblob(data)
-                @fact spatialorder(img) --> so
-            end
+    url = "http://magnushoff.com/assets/test-exiforientation.zip"
+    fn = joinpath(workdir, "test-exiforientation.zip")
+    download(url, fn)
+    first_img = true
+    r = ZipFile.Reader(fn)
+    for f in r.files
+        data = read(f, UInt8, f.uncompressedsize)
+        if first_img
+            img0 = readblob(data)
+            first_img = false
+        else
+            img = readblob(data)
+            @fact all(img0.==img) --> true
         end
     end
-
-    url = "http://www.galloway.me.uk/media/other/EXIF_Orientation_Samples.zip"
-    fn = joinpath(workdir, "EXIF_Orientation_Samples.zip")
-    download(url, fn)
-    r = ZipFile.Reader(fn)
-    test_orientation(r, Dict("up.jpg"=>["x", "y"],
-                             "left-mirrored.jpg"=>["y", "x"]))
+    ZipFile.close(r)
 end


### PR DESCRIPTION
This will require julia-0.5.

With the `PermutedDimsArray` type that's currently buried in julia-0.5, we finally have all the tools in Base to handle image orientation _without_ reference to `Images.Image`. Consequently, we (@Cody-G and I) propose the following overall vision:
- Computer-vision people can do most or all of their processing with plain `Array`, `SubArray`, and `PermutedDimsArray`; this PR is a step along the way to having ImageMagick return an `Array`/`SubArray`/`PermutedDimsArray` rather than an `Images.Image`.
- People who want to encode information about the "meaning" of particular dimensions can wrap the output in an [`AxisArray`](https://github.com/mbauman/AxisArrays.jl) (this probably includes VideoIO, since one wants to encode the existence & meaning of the time dimension).
- The `Images.Image` type will still exist for people who want to attach additional metadata.

The huge win here is that no longer will `img[1:10, 1:10]` throw away orientation information; we no longer require the `Dict` that's in `Image` to encode orientation, so we can finally keep track of it in all operations. We haven't yet started on it, but there will be corresponding work going on revamping Images itself, followed by an update to ImageView. Having gone through several previous transitions (e.g., `FixedPointNumbers` and `ColorTypes`), I am really hoping this will be the last change in the fundamental representation of Images, and once done we can focus on user-experience and algorithms.

Among things missing from this PR is some kind of framework to query the properties of an image file; formerly we tucked that into `load` via keywords, but it seems cleaner to have a separate API for that.

One point worth making is that, without the `Images.Image` wrapper, people may want to add a semicolon at the end of `img = load("imagefile.jpg")` more frequently (because by returning an `Array`, it will dump values to the REPL). Might be a small annoyance--I quite like the compact printing of `Image`, but maybe that's just me.

CC @SimonDanisch, @mbauman, @lucasb-eyer, @rsrock, @bjarthur, @kmsquire.

Again, DO NOT MERGE yet. This is early-stage FYI.
