### PR TITLE
remove deprecation warnings for julia 0.5

### DIFF
--- a/src/ImageMagick.jl
+++ b/src/ImageMagick.jl
@@ -25,7 +25,6 @@ export setimagecompressionquality
 export setimageformat
 export writeimage
 export image2wand
-export writemime_
 
 include("libmagickwand.jl")
 
@@ -243,20 +242,23 @@ to_contiguous(A::Array) = A
 to_contiguous(A::AbstractArray) = copy(A)
 to_contiguous(A::SubArray) = copy(A)
 
-to_explicit(A::AbstractArray) = A
-to_explicit{T<:UFixed}(A::AbstractArray{T}) = reinterpret(FixedPointNumbers.rawtype(T), A)
-to_explicit{T<:UFixed}(A::AbstractArray{RGB{T}}) = reinterpret(FixedPointNumbers.rawtype(T), A, tuple(3, size(A)...))
-to_explicit{T<:AbstractFloat}(A::AbstractArray{RGB{T}}) = to_explicit(map(ClampMinMax(RGB{UFixed8}, zero(RGB{T}), one(RGB{T})), A))
-to_explicit{T<:UFixed}(A::AbstractArray{Gray{T}}) = reinterpret(FixedPointNumbers.rawtype(T), A, size(A))
-to_explicit{T<:AbstractFloat}(A::AbstractArray{Gray{T}}) = to_explicit(map(ClampMinMax(Gray{UFixed8}, zero(Gray{T}), one(Gray{T})), A))
+to_explicit(A::Image) = to_explicit(data(A))
+to_explicit(A::AbstractArray) = to_explicit(copy(A))
 
-to_explicit{T<:UFixed}(A::AbstractArray{GrayA{T}}) = reinterpret(FixedPointNumbers.rawtype(T), A)
-to_explicit{T<:AbstractFloat}(A::AbstractArray{GrayA{T}}) = to_explicit(map(ClampMinMax(GrayA{UFixed8}, zero(GrayA{T}), one(GrayA{T})), A))
+to_explicit{T<:UFixed}(A::Array{T}) = reinterpret(FixedPointNumbers.rawtype(T), A)
 
-to_explicit{T<:UFixed}(A::AbstractArray{BGRA{T}}) = reinterpret(FixedPointNumbers.rawtype(T), A, tuple(4, size(A)...))
-to_explicit{T<:AbstractFloat}(A::AbstractArray{BGRA{T}}) = to_explicit(map(ClampMinMax(BGRA{UFixed8}, zero(BGRA{T}), one(BGRA{T})), A))
-to_explicit{T<:UFixed}(A::AbstractArray{RGBA{T}}) = reinterpret(FixedPointNumbers.rawtype(T), A, tuple(4, size(A)...))
-to_explicit{T<:AbstractFloat}(A::AbstractArray{RGBA{T}}) = to_explicit(map(ClampMinMax(RGBA{UFixed8}, zero(RGBA{T}), one(RGBA{T})), A))
+to_explicit{T<:UFixed}(A::Array{RGB{T}}) = reinterpret(FixedPointNumbers.rawtype(T), A, tuple(3, size(A)...))
+to_explicit{T<:AbstractFloat}(A::Array{RGB{T}}) = to_explicit(map(ClampMinMax(RGB{UFixed8}, zero(RGB{T}), one(RGB{T})), A))
+to_explicit{T<:UFixed}(A::Array{Gray{T}}) = reinterpret(FixedPointNumbers.rawtype(T), A, size(A))
+to_explicit{T<:AbstractFloat}(A::Array{Gray{T}}) = to_explicit(map(ClampMinMax(Gray{UFixed8}, zero(Gray{T}), one(Gray{T})), A))
+
+to_explicit{T<:UFixed}(A::Array{GrayA{T}}) = reinterpret(FixedPointNumbers.rawtype(T), A)
+to_explicit{T<:AbstractFloat}(A::Array{GrayA{T}}) = to_explicit(map(ClampMinMax(GrayA{UFixed8}, zero(GrayA{T}), one(GrayA{T})), A))
+
+to_explicit{T<:UFixed}(A::Array{BGRA{T}}) = reinterpret(FixedPointNumbers.rawtype(T), A, tuple(4, size(A)...))
+to_explicit{T<:AbstractFloat}(A::Array{BGRA{T}}) = to_explicit(map(ClampMinMax(BGRA{UFixed8}, zero(BGRA{T}), one(BGRA{T})), A))
+to_explicit{T<:UFixed}(A::Array{RGBA{T}}) = reinterpret(FixedPointNumbers.rawtype(T), A, tuple(4, size(A)...))
+to_explicit{T<:AbstractFloat}(A::Array{RGBA{T}}) = to_explicit(map(ClampMinMax(RGBA{UFixed8}, zero(RGBA{T}), one(RGBA{T})), A))
 
 
 
@@ -276,7 +278,5 @@ function permutation_horizontal(img)
 end
 
 permutedims_horizontal(img) = permutedims(img, permutation_horizontal(img))
-
-@deprecate writemime_(io::IO, ::MIME"image/png", img::AbstractImage) save(Stream(format"PNG", io), img)
 
 end # module

--- a/src/libmagickwand.jl
+++ b/src/libmagickwand.jl
@@ -215,7 +215,7 @@ function getblob(wand::MagickWand, format::AbstractString)
     setimageformat(wand, format)
     len = Array(Csize_t, 1)
     ptr = ccall((:MagickGetImagesBlob, libwand), Ptr{UInt8}, (Ptr{Void}, Ptr{Csize_t}), wand.ptr, len)
-    blob = pointer_to_array(ptr, convert(Int, len[1]))
+    blob = unsafe_wrap(Array, ptr, convert(Int, len[1]))
     finalizer(blob, relinquishmemory)
     blob
 end
@@ -283,7 +283,7 @@ function getimageproperties(wand::MagickWand,patt::AbstractString)
         nP = convert(Int, numbProp[1])
         ret = Array(Compat.ASCIIString, nP)
         for i = 1:nP
-            ret[i] = bytestring(unsafe_load(p,i))
+            ret[i] = unsafe_string(unsafe_load(p,i))
         end
         ret
     end
@@ -298,7 +298,7 @@ function getimageproperty(wand::MagickWand, prop::AbstractString, warnuser::Bool
         end
         nothing
     else
-        bytestring(p)
+        unsafe_string(p)
     end
 end
 

--- a/test/constructed_images.jl
+++ b/test/constructed_images.jl
@@ -43,7 +43,7 @@ facts("IO") do
         b = ImageMagick.load(fn)
         @fact convert(Array, b) --> aa
         open(fn, "w") do io
-            writemime(io, MIME("image/png"), b; minpixels=0)
+            show(io, MIME("image/png"), b; minpixels=0)
         end
         bb = ImageMagick.load(fn)
         @fact bb.data --> b.data
@@ -69,7 +69,7 @@ facts("IO") do
         @fact Images.data(imgrgb8) --> Images.data(b)
 
         open(fn, "w") do io
-            writemime(io, MIME("image/png"), imgrgb8; minpixels=0)
+            show(io, MIME("image/png"), imgrgb8; minpixels=0)
         end
         bb = ImageMagick.load(fn)
         @fact data(bb) --> data(imgrgb8)
@@ -148,7 +148,7 @@ facts("IO") do
         @fact B --> map(Gray{UFixed8}, A)
     end
 
-    @unix_only context("Reading from a stream (issue #312)") do
+    is_unix() && context("Reading from a stream (issue #312)") do
         fn = joinpath(workdir, "2by2.png")
         img = open(fn) do io
             ImageMagick.load(io)
@@ -156,7 +156,7 @@ facts("IO") do
         @fact isa(img, Images.Image) --> true
     end
 
-    @unix_only context("Writing to a stream (PR #22)") do
+    is_unix() && context("Writing to a stream (PR #22)") do
         orig_img = ImageMagick.load(joinpath(workdir, "2by2.png"))
         fn = joinpath(workdir, "2by2_fromstream.png")
         open(fn, "w") do f
@@ -166,7 +166,7 @@ facts("IO") do
         @fact img --> orig_img
     end
 
-    @unix_only context("Reading from a byte array (issue #279)") do
+    is_unix() && context("Reading from a byte array (issue #279)") do
         fn = joinpath(workdir, "2by2.png")
         io = open(fn)
         arr = read(io)
@@ -175,13 +175,13 @@ facts("IO") do
         @fact isa(img, Images.Image) --> true
     end
 
-    context("writemime") do
+    context("show(MIME)") do
         Ar = rand(UInt8, 3, 2, 2)
         Ar[1] = typemax(eltype(Ar))
         a = colorim(Ar)
         fn = joinpath(workdir, "2by2.png")
         open(fn, "w") do file
-            writemime(file, MIME("image/png"), a, minpixels=0)
+            show(file, MIME("image/png"), a, minpixels=0)
         end
         b = ImageMagick.load(fn)
         @fact data(b) --> data(a)
@@ -191,7 +191,7 @@ facts("IO") do
         abig = colorim(Ar)
         fn = joinpath(workdir, "big.png")
         open(fn, "w") do file
-            writemime(file, MIME("image/png"), abig, maxpixels=10^6)
+            show(file, MIME("image/png"), abig, maxpixels=10^6)
         end
         b = ImageMagick.load(fn)
         @fact data(b) --> convert(Array{RGB{UFixed8},2}, data(restrict(abig, (1,2))))
@@ -201,7 +201,7 @@ facts("IO") do
         Ar[1] = typemax(eltype(Ar))
         abig = colorim(Ar)
         open(fn, "w") do file
-            writemime(file, MIME("image/png"), abig, maxpixels=10^6)
+            show(file, MIME("image/png"), abig, maxpixels=10^6)
         end
         b = ImageMagick.load(fn)
         @fact data(b) --> convert(Array{RGB{UFixed8},2}, data(restrict(abig, (1,2))))

--- a/test/readremote.jl
+++ b/test/readremote.jl
@@ -40,7 +40,7 @@ facts("Read remote") do
         imgrgb8 = map(mapi, img)
         @fact imgrgb8[1,1].r --> img[1].val
         open(outname, "w") do file
-            writemime(file, "image/png", img)
+            show(file, MIME("image/png"), img)
         end
     end
 
@@ -51,14 +51,14 @@ facts("Read remote") do
         @fact ndims(img) --> 2
         @fact colordim(img) --> 0
         @fact eltype(img) --> Images.ColorTypes.GrayA{UFixed8}
-        @linux_only begin
+        if is_linux()
             outname = joinpath(writedir, "wmark_image.png")
             ImageMagick.save(outname, img)
             sleep(0.2)
             imgc = ImageMagick.load(outname)
             @fact img.data --> imgc.data
             open(outname, "w") do file
-                writemime(file, "image/png", img)
+                show(file, MIME("image/png"), img)
             end
         end
         @fact reinterpret(UInt32, data(map(mapinfo(RGB24, img), img))) -->
@@ -79,7 +79,7 @@ facts("Read remote") do
         imgc = ImageMagick.load(outname)
         T = eltype(imgc)
         # Why does this one fail on OSX??
-        @osx? nothing : @fact img.data --> imgc.data
+        is_apple() || @fact img.data --> imgc.data
         @fact reinterpret(UInt32, data(map(mapinfo(RGB24, img), img))) -->
             map(x->x&0x00ffffff, reinterpret(UInt32, data(map(mapinfo(ARGB32, img), img))))
         @fact mapinfo(UInt32, img) --> mapinfo(RGB24, img)
@@ -105,7 +105,7 @@ facts("Read remote") do
         imr = reinterpret(UFixed8, img)
         uint32color(imr)
         uint32color!(buf, imr)
-        @osx? nothing : begin
+        is_apple() || begin
             imhsv = convert(Image{HSV}, float32(img))
             uint32color(imhsv)
             uint32color!(buf, imhsv)
@@ -113,7 +113,7 @@ facts("Read remote") do
         end
         outname = joinpath(writedir, "rose.png")
         open(outname, "w") do file
-            writemime(file, "image/png", img)
+            show(file, MIME("image/png"), img)
         end
     end
 
@@ -125,7 +125,7 @@ facts("Read remote") do
         @fact colordim(img) --> 0
         @fact eltype(img) --> Images.ColorTypes.BGRA{UFixed16}
         outname = joinpath(writedir, "autumn_leaves.png")
-        @osx? nothing : begin
+        is_apple() || begin
             ImageMagick.save(outname, img)
             sleep(0.2)
             imgc = ImageMagick.load(outname)
@@ -135,7 +135,7 @@ facts("Read remote") do
             @fact mapinfo(UInt32, img) --> mapinfo(ARGB32, img)
         end
         open(outname, "w") do file
-            writemime(file, "image/png", img)
+            show(file, MIME("image/png"), img)
         end
     end
 
@@ -148,7 +148,7 @@ facts("Read remote") do
         @fact mapinfo(UInt32, img) --> mapinfo(RGB24, img)
         outname = joinpath(writedir, "present.png")
         open(outname, "w") do file
-            writemime(file, "image/png", img)
+            show(file, MIME("image/png"), img)
         end
     end
 
@@ -178,7 +178,7 @@ facts("Read remote") do
     end
 
     context("Extra properties") do
-        @osx? nothing : begin
+        is_apple() || begin
             file = getfile("autumn_leaves.png")
             # List properties
             extraProps = ImageMagick.load(file, extrapropertynames=true)


### PR DESCRIPTION
this fixes `ImageMagick` for julia 0.5, but breaks it for 0.4.  the `bytestring` -> `unsafe_string` could be easily fixed with a `@compat`, but what can be done about `@linux_only` -> `if is_linux()` ?

https://github.com/timholy/Images.jl/pull/515#issuecomment-233065664
