### PR TITLE
Adding seeking to an arbitrary position in a multiframe image

### DIFF
--- a/src/ImageMagick.jl
+++ b/src/ImageMagick.jl
@@ -5,7 +5,7 @@ using Compat
 import Compat.String
 
 using FixedPointNumbers, ColorTypes, Images, ColorVectorSpace
-using FileIO: DataFormat, @format_str, Stream, File, filename, stream
+using FileIO: DataFormat, @format_str, Stream, File, filename, stream, query, skipmagic
 
 export MagickWand
 export constituteimage
@@ -75,22 +75,38 @@ const ufixedtype = Dict(10=>UFixed10, 12=>UFixed12, 14=>UFixed14, 16=>UFixed16)
 
 readblob(data::Vector{UInt8}) = load_(data)
 
-function load_(file::Union{AbstractString,IO,Vector{UInt8}}; ImageType=Image, extraprop="", extrapropertynames=false)
+function load_(file::Union{AbstractString,IO,Vector{UInt8}}; ImageType=Image, extraprop="", extrapropertynames=false, seekFrame=1, nframes=0)
     wand = MagickWand()
     readimage(wand, file)
     resetiterator(wand)
-
+    
     if extrapropertynames
         return(getimageproperties(wand, "*"))
     end
 
     # Determine what we need to know about the image format
-    sz = size(wand)
+    szIm = size(wand)
     n = getnumberimages(wand)
+
+    if seekFrame > 2
+        seekFrame > n ? error("Can't seek frame $(seekFrame), only $(n) frames in the movie."):
+        setimageindex(wand,seekFrame-2)   ## Because Libmagickwand uses 0 indexing, and setting the iterator sets it at the end of the image
+    end
+    
+    if nframes > 0
+        n = minimum([n-seekFrame+2,nframes])
+    end
+    
+        
     if n > 1
-        sz = tuple(sz..., n)
+        sz = tuple(szIm..., n)
+    else
+        sz= szIm
     end
 
+    
+
+    
     imtype      = getimagetype(wand)
     havealpha   = getimagealphachannel(wand)
     cs          = getimagecolorspace(wand)
@@ -129,6 +145,7 @@ function load_(file::Union{AbstractString,IO,Vector{UInt8}}; ImageType=Image, ex
     end
     # Allocate the buffer and get the pixel data
     buf = Array(T, sz...)
+    
     exportimagepixels!(buf, wand, cs, channelorder)
 
     prop = Dict{Compat.UTF8String, Any}()

--- a/src/ImageMagick.jl
+++ b/src/ImageMagick.jl
@@ -5,7 +5,7 @@ using Compat
 import Compat.String
 
 using FixedPointNumbers, ColorTypes, Images, ColorVectorSpace
-using FileIO: DataFormat, @format_str, Stream, File, filename, stream, query, skipmagic
+using FileIO: DataFormat, @format_str, Stream, File, filename, stream
 
 export MagickWand
 export constituteimage

--- a/src/libmagickwand.jl
+++ b/src/libmagickwand.jl
@@ -15,7 +15,8 @@ export MagickWand,
     setimagecompression,
     setimagecompressionquality,
     setimageformat,
-    writeimage
+    writeimage,
+    setimageindex
 
     # Find the library
 depsfile = joinpath(dirname(@__FILE__),"..","deps","deps.jl")
@@ -267,6 +268,9 @@ getnumberimages(wand::MagickWand) = convert(Int, ccall((:MagickGetNumberImages, 
 nextimage(wand::MagickWand) = ccall((:MagickNextImage, libwand), Cint, (Ptr{Void},), wand.ptr) == 1
 
 resetiterator(wand::MagickWand) = ccall((:MagickResetIterator, libwand), Void, (Ptr{Void},), wand.ptr)
+
+## Seeking a position in the wand 
+setimageindex(wand::MagickWand,imindex::Integer) = ccall((:MagickSetIteratorIndex, libwand),Ptr{Void},(Ptr{Void},Csize_t),wand.ptr,imindex)
 
 newimage(wand::MagickWand, cols::Integer, rows::Integer, pw::PixelWand) = ccall((:MagickNewImage, libwand), Cint, (Ptr{Void}, Csize_t, Csize_t, Ptr{Void}), wand.ptr, cols, rows, pw.ptr) == 0 && error(wand)
 

--- a/test/readremote.jl
+++ b/test/readremote.jl
@@ -201,6 +201,16 @@ facts("Read remote") do
             @fact props["Non existing property"] --> nothing
         end
     end
+
+    context("Seeking frames") do
+        fname = "plane.avi"
+        file = getfile(fname)  
+        img = ImageMagick.load(file)
+        subIm = ImageMagick.load(file,seekFrame=50,nframes=5)
+        @fact nimages(subIm) --> 5
+        @fact img[:,:,50] --> subIm[:,:,1]
+    end
+
 end
 
 facts("EXIF orientation") do


### PR DESCRIPTION
Could be useful to access specific frames in a video without loading the full video. It uses the `MagickSetIteratorIndex` function from `libmagickwand`. 
Works with two keyword arguments `seekFrame`, and `nframes` that do what you'd expect (get `nframes` at frame number `seekFrame`).

Example use : 

``` julia
using FileIO
fn = Pkg.dir("FileIO","test","files","bees.avi")
smallBee = load(fn,seekFrame=15 ,nframes=3)
RGB Images.Image with:
  data: 640×480×3 Array{ColorTypes.RGB{FixedPointNumbers.UFixed{UInt8,8}},3}
  properties:
    timedim: 3
    colorspace: sRGB
    spatialorder:  x y
smallBee[:,:,1] == load(fn)[:,:,15]
```

I only tried it on Ubuntu.
