### PR TITLE
on OS X use staticfloat/juliadeps/imagemagick@6

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,10 @@
 [![Coverage Status](https://coveralls.io/repos/JuliaIO/ImageMagick.jl/badge.svg?branch=master&service=github)](https://coveralls.io/github/JuliaIO/ImageMagick.jl?branch=master)
 [![codecov.io](http://codecov.io/github/JuliaIO/ImageMagick.jl/coverage.svg?branch=master)](http://codecov.io/github/JuliaIO/ImageMagick.jl?branch=master)
 
-This package was split off from [Images.jl](https://github.com/timholy/Images.jl) to make image I/O more modular.
+This package provides a wrapper around
+[ImageMagick](http://www.imagemagick.org/) version 6.  It was split off from
+[Images.jl](https://github.com/timholy/Images.jl) to make image I/O more
+modular.
 
 # Installation
 
@@ -33,10 +36,9 @@ It's worth pointing out that packages such as Images load FileIO.
 
 ## OSX
 
-ImageMagick.jl will by default not use the system installed ImageMagic in
-`/usr/local`, but rather install it's own copy via Homebrew.jl, because the
-former results in problems like `ERROR: no encode delegate for this image format
-'MIFF'`.
+ImageMagick.jl will use the system-wide libMagicWand in `/usr/local/lib` if
+present (e.g. via a manual installation with homebrew).  If not it will install
+its own copy via Homebrew.jl.
 
 An alternative to ImageMagick on OS X is
 [QuartzImageIO](https://github.com/JuliaIO/QuartzImageIO.jl).

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -80,29 +80,26 @@ end
 
 if is_apple()
     using Homebrew
+    imagemagick_prefix = Homebrew.prefix("imagemagick@6")
     initfun_homebrew =
 """
 function init_deps()
-    ENV["MAGICK_CONFIGURE_PATH"] = joinpath("$(Homebrew.prefix("imagemagick"))","lib","ImageMagick","config-Q16")
-    ENV["MAGICK_CODER_MODULE_PATH"] = joinpath("$(Homebrew.prefix("imagemagick"))", "lib","ImageMagick","modules-Q16","coders")
-    ENV["PATH"] = joinpath("$(Homebrew.prefix("imagemagick"))", "bin") * ":" * ENV["PATH"]
+    ENV["MAGICK_CONFIGURE_PATH"] = joinpath("$(imagemagick_prefix)","lib","ImageMagick","config-Q16")
+    ENV["MAGICK_CODER_MODULE_PATH"] = joinpath("$(imagemagick_prefix)", "lib","ImageMagick","modules-Q16","coders")
+    ENV["PATH"] = joinpath("$(imagemagick_prefix)", "bin") * ":" * ENV["PATH"]
     ccall((:MagickWandGenesis,libwand), Void, ())
 end
 """
-    provides( Homebrew.HB, "imagemagick", libwand, os = :Darwin, preload = initfun_homebrew, onload="init_deps()")
+    provides( Homebrew.HB, "staticfloat/juliadeps/imagemagick@6", libwand, os = :Darwin, preload = initfun_homebrew, onload="init_deps()")
 
-    if success(`brew list imagemagick`) 
-        brew_config = readlines(`brew config`);
-        idx = findfirst(x->startswith(x,"HOMEBREW_PREFIX"), brew_config)
-        brew_config[idx][18:end-1]
-        homebrew_prefix = brew_config[idx][18:end-1]
-
+    if success(`brew list imagemagick@6`) 
+        homebrew_prefix = readchomp(`brew --prefix`)
         initfun_system_homebrew =
 """
 function init_deps()
-    ENV["MAGICK_CONFIGURE_PATH"] = joinpath($(homebrew_prefix),"lib","ImageMagick","config-Q16")
-    ENV["MAGICK_CODER_MODULE_PATH"] = joinpath($(homebrew_prefix), "lib","ImageMagick","modules-Q16","coders")
-    ENV["PATH"] = joinpath($(homebrew_prefix), "bin") * ":" * ENV["PATH"]
+    ENV["MAGICK_CONFIGURE_PATH"] = joinpath("$(homebrew_prefix)","lib","ImageMagick","config-Q16")
+    ENV["MAGICK_CODER_MODULE_PATH"] = joinpath("$(homebrew_prefix)", "lib","ImageMagick","modules-Q16","coders")
+    ENV["PATH"] = joinpath("$(homebrew_prefix)", "bin") * ":" * ENV["PATH"]
     ccall((:MagickWandGenesis,libwand), Void, ())
 end
 """


### PR DESCRIPTION
this PR fixes the mess that homebrew created a few days ago when they updated their formulae to only support libImageMagick v7.0.4.  we now directly install the v6 bottle kindly provided by @staticfloat in Homebrew.jl.

while at it i also took the liberty to update the README a bit, specifically mentioning that ImageMagick.jl only supports libimagemagick v6.