### PR TITLE
Revert "Hacks to get CI passing (revert later)"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ notifications:
 # uncomment the following lines to override the default test script
 script:
   - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
-  - julia -e 'Pkg.add("Images"); Pkg.checkout("Images", "fixed-renaming")'
+  - julia -e 'Pkg.clone("Images");'
   - julia -e 'Pkg.clone(pwd()); Pkg.build("ImageMagick")'
   - julia --check-bounds=yes -e 'Pkg.test("ImageMagick"; coverage=true)'
 after_success:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,7 +26,6 @@ build_script:
 # Need to convert from shallow to complete for Pkg.clone to work
   - IF EXIST .git\shallow (git fetch --unshallow)
   - C:\projects\julia\bin\julia-debug -e "versioninfo(); Pkg.init();"
-  - C:\projects\julia\bin\julia-debug -e "Pkg.add(\"Images\"); Pkg.checkout(\"Images\",\"fixed-renaming\");"
   - C:\projects\julia\bin\julia-debug -e "Pkg.clone(pwd(), \"ImageMagick\");"
   - C:\projects\julia\bin\julia-debug -e "Pkg.build(\"ImageMagick\")"
 


### PR DESCRIPTION
This reverts commit 5c5f6ebae0601a21627e9df71aa4497a85df0338.

ImageMagick itself is not dependent on Images anymore, but it is for the tests. Now that the new Images has been tagged, we can remove the code that caused a particular branch to be checked out before running tests.