### PR TITLE
require and load Images instead of ImageCore

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -2,7 +2,7 @@ julia 0.5
 Compat 0.18.0
 FixedPointNumbers 0.3.0
 ColorTypes 0.2.7
-ImageCore 0.1.0
+Images 0.6
 FileIO
 @osx Homebrew
 BinDeps

--- a/src/ImageMagick.jl
+++ b/src/ImageMagick.jl
@@ -2,7 +2,7 @@ __precompile__()
 
 module ImageMagick
 
-using FixedPointNumbers, ColorTypes, ImageCore
+using FixedPointNumbers, ColorTypes, Images
 using FileIO: DataFormat, @format_str, Stream, File, filename, stream
 using Compat
 


### PR DESCRIPTION
This ensures that the image display logic from Images.jl is loaded instead of the SVG
display logic from Colors.jl.

Resolves https://github.com/JuliaImages/Images.jl/issues/619

@timholy Images v0.6 looks like the closest match to ImageCore v0.1, since they were released together. I've run the ImageMagick.jl tests with Images.jl fixed to v0.6 with no issues, so I think it's a good lower bound. I tested this by running:

```julia
julia> for minor in 6:9
       Pkg.pin("Images", VersionNumber(0, minor, 0))
       rm("/home/rdeits/.julia/lib/v0.5/ImageMagick.ji")  # precompilation gets confused when ImageTransformations.jl disappears
       Pkg.test("ImageMagick")
end
```

on Ubuntu 14.04. 