### PR TITLE
Support non-1 indices

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,5 +1,5 @@
 julia 0.5
-Compat 0.18.0
+Compat 0.24
 FixedPointNumbers 0.3.0
 ColorTypes 0.2.7
 Images 0.6

--- a/src/ImageMagick.jl
+++ b/src/ImageMagick.jl
@@ -228,8 +228,7 @@ mapIM(x::Normed) = x
 # Make the data contiguous in memory, this is necessary for
 # imagemagick since it doesn't handle stride.
 to_contiguous(A::Array) = A
-to_contiguous(A::AbstractArray) = convert(Array, A)
-to_contiguous(A::SubArray) = copy(A)
+to_contiguous(A::AbstractArray) = Compat.collect(A)
 to_contiguous(A::BitArray) = convert(Array{N0f8}, A)
 to_contiguous(A::ColorView) = to_contiguous(channelview(A))
 

--- a/test/constructed_images.jl
+++ b/test/constructed_images.jl
@@ -99,13 +99,13 @@ type TestType end
         b = RGB(0,0,1)
         w = RGB(1,1,1)
         r = RGB(1,0,0)
-        cmaprgb = Array(RGB{Float64}, 255)
+        cmaprgb = Array{RGB{Float64}}(255)
         f = linspace(0,1,128)
         cmaprgb[1:128] = [(1-x)*b + x*w for x in f]
         cmaprgb[129:end] = [(1-x)*w + x*r for x in f[2:end]]
         img = IndirectArray(dataint, cmaprgb)
         ImageMagick.save(joinpath(workdir,"cmap.jpg"), img)
-        cmaprgb = Array(RGB, 255) # poorly-typed cmap, issue #336
+        cmaprgb = Array{RGB}(255) # poorly-typed cmap, Images issue #336
         cmaprgb[1:128] = [(1-x)*b + x*w for x in f]
         cmaprgb[129:end] = [(1-x)*w + x*r for x in f[2:end]]
         img = IndirectArray(dataint, cmaprgb)

--- a/test/constructed_images.jl
+++ b/test/constructed_images.jl
@@ -1,4 +1,4 @@
-using ImageMagick, ColorTypes, FixedPointNumbers, IndirectArrays, FileIO
+using ImageMagick, ColorTypes, FixedPointNumbers, IndirectArrays, FileIO, OffsetArrays
 using Images       # for show(io, ::MIME, img) & ImageMeta
 using Compat       # for I/O redirection
 using Base.Test
@@ -267,6 +267,14 @@ type TestType end
         ImageMagick.save(fn, img)
         imgr = ImageMagick.load(fn)
         @test imgr == img
+    end
+
+    @testset "OffsetArrays" begin
+        img = OffsetArray([true false; false true], 0:1, 3:4)
+        fn = joinpath(workdir, "indices.png")
+        ImageMagick.save(fn, img)
+        imgr = ImageMagick.load(fn)
+        @test imgr == parent(img)
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,3 +4,8 @@ info("ImageMagick version ", ImageMagick.libversion)
 
 include("constructed_images.jl")
 include("readremote.jl")
+
+workdir = joinpath(tempdir(), "Images")
+try
+    rm(workdir, recursive=true)
+end


### PR DESCRIPTION
Similar changes might be desired in QuartzImageIO, CC @rsrock.

Tests expected to fail on 0.6 due to https://github.com/JuliaLang/julia/issues/21369, but if you run the tests a second time in the same session, it passes locally on 0.6.
