### PR TITLE
Fix OSX Homebrew build issues and made build script more consistent

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ os:
   - osx
 julia:
   - 0.5
+  - 0.6
   - nightly
 notifications:
   email: false

--- a/README.md
+++ b/README.md
@@ -36,9 +36,12 @@ It's worth pointing out that packages such as Images load FileIO.
 
 ## OSX
 
-ImageMagick.jl will use the system-wide libMagicWand in `/usr/local/lib` if
-present (e.g. via a manual installation with homebrew).  If not it will install
-its own copy via Homebrew.jl.
+ImageMagick.jl will use the system-wide libMagicWand in `/usr/local/lib` if it is
+present.  Use the environment variable `MAGICK_HOME` to add other paths to the search
+path. Note that version 6.7+ (up to but not including 7.0) are the most supported versions, in
+particular for multipage TIFFs.  Use `ImageMagick.libversion` to see what version the installer
+found.  If ImageMagick.jl doesn't find a previous installation, it will install its own copy of the
+ImageMagick library with Homebrew.jl.
 
 An alternative to ImageMagick on OS X is
 [QuartzImageIO](https://github.com/JuliaIO/QuartzImageIO.jl).

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,6 +2,8 @@ environment:
   matrix:
   - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.5/julia-0.5-latest-win32.exe"
   - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.5/julia-0.5-latest-win64.exe"
+  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.6/julia-0.6-latest-win32.exe"
+  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.6/julia-0.6-latest-win64.exe"
   - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x86/julia-latest-win32.exe"
   - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x64/julia-latest-win64.exe"
 

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -7,36 +7,45 @@ suffixes    = ["", "-Q16", "-6.Q16", "-Q8"]
 options     = ["", "HDRI"]
 extensions  = ["", ".so.2", ".so.4", ".so.5"]
 aliases     = vec(libnames .*
-                  reshape(suffixes,(1,length(suffixes))) .*
-                  reshape(options,(1,1,length(options))) .*
-                  reshape(extensions,(1,1,1,length(extensions))))
+                  reshape(suffixes, (1, length(suffixes))) .*
+                  reshape(options, (1, 1, length(options))) .*
+                  reshape(extensions, (1, 1, 1, length(extensions))))
 libwand     = library_dependency("libwand", aliases = aliases)
 
-initfun = """
-function init_deps()
-    ccall((:MagickWandGenesis,libwand), Void, ())
-end
-"""
 
 mpath = get(ENV, "MAGICK_HOME", "") # If MAGICK_HOME is defined, add to library search path
 if !isempty(mpath)
-    provides(Binaries, mpath, libwand)
-    provides(Binaries, joinpath(mpath,"lib"), libwand)
+    init_fun =
+        """
+        function init_deps()
+            ccall((:MagickWandGenesis, libwand), Void, ())
+        end
+        """
+
+    provides(Binaries, mpath, libwand, preload = init_fun, onload = "init_deps()")
+    provides(Binaries, joinpath(mpath, "lib"), libwand, preload = init_fun, onload = "init_deps()")
 end
+
 
 if is_linux()
-    kwargs = Any[(:onload, initfun)]
-    provides(AptGet, "libmagickwand4", libwand; kwargs...)
-    provides(AptGet, "libmagickwand5", libwand; kwargs...)
-    provides(AptGet, "libmagickwand-6.q16-2", libwand; kwargs...)
-    provides(Pacman, "imagemagick", libwand; kwargs...)
-    provides(Yum, "ImageMagick", libwand; kwargs...)
+    init_fun =
+        """
+        function init_deps()
+            ccall((:MagickWandGenesis, libwand), Void, ())
+        end
+        """
+
+    provides(AptGet, "libmagickwand4", preload = init_fun, onload = "init_deps()")
+    provides(AptGet, "libmagickwand5", preload = init_fun, onload = "init_deps()")
+    provides(AptGet, "libmagickwand-6.q16-2", preload = init_fun, onload = "init_deps()")
+    provides(Pacman, "imagemagick", libwand, preload = init_fun, onload = "init_deps()")
+    provides(Yum, "ImageMagick", libwand, preload = init_fun, onload = "init_deps()")
 end
 
-# TODO: remove me when upstream is fixed
-is_windows() && push!(BinDeps.defaults, BuildProcess)
 
 if is_windows()
+    push!(BinDeps.defaults, BuildProcess) # TODO: remove me when upstream is fixed
+
     const OS_ARCH = Sys.WORD_SIZE == 64 ? "x64" : "x86"
 
     # TODO: checksums: we have gpg
@@ -52,14 +61,13 @@ if is_windows()
     magick_url      = "$(magick_base)/$(magick_exe)"
     magick_libdir   = joinpath(BinDeps.libdir(libwand), OS_ARCH)
     innounp_url     = "https://bintray.com/artifact/download/julialang/generic/innounp.exe"
-    initfun         =
-"""
-function init_deps()
-    ENV["MAGICK_CONFIGURE_PATH"]    = \"$(escape_string(magick_libdir))\"
-    ENV["MAGICK_CODER_MODULE_PATH"] = \"$(escape_string(magick_libdir))\"
-end
-init_deps()
-"""
+    init_fun         =
+        """
+        function init_deps()
+            ENV["MAGICK_CONFIGURE_PATH"]    = \"$(escape_string(magick_libdir))\"
+            ENV["MAGICK_CODER_MODULE_PATH"] = \"$(escape_string(magick_libdir))\"
+        end
+        """
 
     provides(BuildProcess,
         (@build_steps begin
@@ -73,55 +81,43 @@ init_deps()
                 `innounp.exe -q -y -b -e -x -d$(magick_libdir) $(magick_exe)`
             end
         end),
-        libwand, os = :Windows, unpacked_dir = magick_libdir, preload = initfun)
+        libwand, os = :Windows, unpacked_dir = magick_libdir, preload = init_fun,
+        onload = "init_deps()")
 end
+
 
 if is_apple()
     using Homebrew
     imagemagick_prefix = Homebrew.prefix("homebrew/core/imagemagick@6")
-    initfun_homebrew =
-"""
-function init_deps()
-    ENV["MAGICK_CONFIGURE_PATH"] = joinpath("$(imagemagick_prefix)","lib","ImageMagick","config-Q16")
-    ENV["MAGICK_CODER_MODULE_PATH"] = joinpath("$(imagemagick_prefix)", "lib","ImageMagick","modules-Q16","coders")
-    ENV["PATH"] = joinpath("$(imagemagick_prefix)", "bin") * ":" * ENV["PATH"]
-    ccall((:MagickWandGenesis,libwand), Void, ())
-end
-"""
-    provides( Homebrew.HB, "homebrew/core/imagemagick@6", libwand, os = :Darwin, preload = initfun_homebrew, onload="init_deps()")
+    init_fun =
+        """
+        function init_deps()
+            ENV["MAGICK_CONFIGURE_PATH"] = joinpath("$(imagemagick_prefix)",
+                                                    "lib", "ImageMagick", "config-Q16")
+            ENV["MAGICK_CODER_MODULE_PATH"] = joinpath("$(imagemagick_prefix)",
+                                                       "lib", "ImageMagick", "modules-Q16", "coders")
+            ENV["PATH"] = joinpath("$(imagemagick_prefix)", "bin") * ":" * ENV["PATH"]
 
-    if success(`brew list imagemagick@6`) 
-        homebrew_prefix = readchomp(`brew --prefix`)
-        initfun_system_homebrew =
-"""
-function init_deps()
-    ENV["MAGICK_CONFIGURE_PATH"] = joinpath("$(homebrew_prefix)","lib","ImageMagick","config-Q16")
-    ENV["MAGICK_CODER_MODULE_PATH"] = joinpath("$(homebrew_prefix)", "lib","ImageMagick","modules-Q16","coders")
-    ENV["PATH"] = joinpath("$(homebrew_prefix)", "bin") * ":" * ENV["PATH"]
-    ccall((:MagickWandGenesis,libwand), Void, ())
+            ccall((:MagickWandGenesis,libwand), Void, ())
+        end
+        """
+    provides(Homebrew.HB, "homebrew/core/imagemagick@6", libwand, os = :Darwin,
+             preload = init_fun, onload = "init_deps()")
 end
-"""
-        provides(Binaries, homebrew_prefix, libwand, os = :Darwin, preload = initfun_system_homebrew, onload="init_deps()")
-    end
-end
+
 
 @BinDeps.install Dict([(:libwand, :libwand)])
 
-# Hack-fix for issue #12
-# Check to see whether init_deps is present, and if not add it
-if isempty(search(readstring(joinpath(dirname(@__FILE__),"deps.jl")), "init_deps"))
-    open("deps.jl", "a") do io
-        write(io, initfun)
+
+module CheckVersion
+    include("deps.jl")
+    p = ccall((:MagickQueryConfigureOption, libwand), Ptr{UInt8}, (Ptr{UInt8}, ),
+              "LIB_VERSION_NUMBER")
+    vstr = string("v\"", join(split(unsafe_string(p), ',')[1:3], '.'), "\"")
+    open(joinpath(dirname(@__FILE__), "versioninfo.jl"), "w") do file
+        write(file, "const libversion = $vstr\n")
     end
 end
 
-module CheckVersion
-include("deps.jl")
-p = ccall((:MagickQueryConfigureOption, libwand), Ptr{UInt8}, (Ptr{UInt8},), "LIB_VERSION_NUMBER")
-vstr = string("v\"", join(split(unsafe_string(p), ',')[1:3], '.'), "\"")
-open(joinpath(dirname(@__FILE__),"versioninfo.jl"), "w") do file
-    write(file, "const libversion = $vstr\n")
-end
-end
 
 is_windows() && pop!(BinDeps.defaults)

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -35,9 +35,9 @@ if is_linux()
         end
         """
 
-    provides(AptGet, "libmagickwand4", preload = init_fun, onload = "init_deps()")
-    provides(AptGet, "libmagickwand5", preload = init_fun, onload = "init_deps()")
-    provides(AptGet, "libmagickwand-6.q16-2", preload = init_fun, onload = "init_deps()")
+    provides(AptGet, "libmagickwand4", libwand, preload = init_fun, onload = "init_deps()")
+    provides(AptGet, "libmagickwand5", libwand, preload = init_fun, onload = "init_deps()")
+    provides(AptGet, "libmagickwand-6.q16-2", libwand, preload = init_fun, onload = "init_deps()")
     provides(Pacman, "imagemagick", libwand, preload = init_fun, onload = "init_deps()")
     provides(Yum, "ImageMagick", libwand, preload = init_fun, onload = "init_deps()")
 end
@@ -88,7 +88,7 @@ end
 
 if is_apple()
     using Homebrew
-    imagemagick_prefix = Homebrew.prefix("homebrew/core/imagemagick@6")
+    imagemagick_prefix = Homebrew.prefix("staticfloat/juliadeps/imagemagick@6")
     init_fun =
         """
         function init_deps()
@@ -101,7 +101,7 @@ if is_apple()
             ccall((:MagickWandGenesis,libwand), Void, ())
         end
         """
-    provides(Homebrew.HB, "homebrew/core/imagemagick@6", libwand, os = :Darwin,
+    provides(Homebrew.HB, "staticfloat/juliadeps/imagemagick@6", libwand, os = :Darwin,
              preload = init_fun, onload = "init_deps()")
 end
 


### PR DESCRIPTION
For a while now, we've had issues with OSX builds breaking, sometimes even resulting in a segfault:

- https://github.com/JuliaPackaging/Homebrew.jl/issues/175
- https://github.com/JuliaPackaging/Homebrew.jl/issues/176
- https://github.com/JuliaPackaging/Homebrew.jl/issues/178
- https://github.com/JuliaIO/ImageMagick.jl/issues/66
- https://github.com/JuliaIO/ImageMagick.jl/issues/74
- https://github.com/JuliaIO/ImageMagick.jl/issues/75

It's likely that these issues have different root causes, but at least one of them has to do with the way Homebrew.jl handles the translation from `homebrew/core` to `staticfloat/juliadeps`.

In some cases, the ImageMagick.jl build script would ask for the Homebrew prefix to the homebrew/core/imagemagick@6 library, but the Julia homebrew library would still have the staticfloat/juliadeps version installed. Rebuilding the library would _not_ replace the installed version (despite calling for "homebrew/core/imagemagick@6"), but it _would_ update `deps.jl` to point to the new version—resulting in errors. After testing and merging of the PR, we should probably tag a new version of the package to fix this for the users that filed issues.

This PR includes three sets of changes:

1. The package always calls for the staticfloat/juliadeps version—both upon the initial installation and upon rebuilding later on. This should prevent inconsistencies between the installed library and `deps.jl`.
2. The PR also removed the automatic detection of a system-wide Homebrew installed ImageMagick library, since the detect call (`success('brew list imagemagick@6'`) isn't consistent. After loading the Homebrew package in Julia, the detect call would call the Julia Homebrew, rather than the system-wide Homebrew—which in rare cases would lead to further inconsistencies. The PR now uses the `MAGICK_HOME` environment variable to allow users to specify their own installation of ImageMagick—similar to the Unix version of the package.
3. General formatting and consistency fixes. Each platform now uses a similar build script to make maintaining the package a bit easier.

Note that some users that have tried to fix the issue manually in the past by taking control of Julia's Homebrew might have to manually remove the library installed by Homebrew.jl, prune the remaining symlinks, and rebuild the ImageMagick package:
```julia
using Homebrew
run(`brew remove imagemagick@6`)
run(`brew prune`)
Pkg.build("ImageMagick")
```