### PR TITLE
General build and init fixes and improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ necessary changes to take effect.**
 
 ImageMagick.jl automatically searches for an installed version of
 libMagickWand.  Use the environment variable `MAGICK_HOME` to add to the search
-path.  Use `ImageMagick.libversion` to see what version it found.  Version 6.7+
+path.  Use `ImageMagick.libversion()` to see what version it found.  Version 6.7+
 (up to but not including 7.0) are the most supported versions, in particular
 for multipage TIFFs.
 

--- a/README.md
+++ b/README.md
@@ -49,14 +49,14 @@ some of your workarounds might interfere with the new approach. You can reset yo
 
 ```julia
 using Homebrew
-run(`brew remove imagemagick@6`)
-run(`brew prune`)
+Homebrew.rm("imagemagick@6")
+Homebrew.brew(`prune`)
 Pkg.build("ImageMagick")
 ```
 
 You may also find [debugging
 Homebrew](https://github.com/JuliaLang/Homebrew.jl/wiki/Debugging-Homebrew.jl)
-useful. 
+useful.
 
 Finally, an alternative to ImageMagick on OS X is
 [QuartzImageIO](https://github.com/JuliaIO/QuartzImageIO.jl).

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -88,20 +88,20 @@ end
 
 if is_apple()
     using Homebrew
-    imagemagick_prefix = Homebrew.prefix("staticfloat/juliadeps/imagemagick@6")
+    homebrew_prefix = Homebrew.prefix()
     init_fun =
         """
         function init_deps()
-            ENV["MAGICK_CONFIGURE_PATH"] = joinpath("$(imagemagick_prefix)",
+            ENV["MAGICK_CONFIGURE_PATH"] = joinpath("$(homebrew_prefix)",
                                                     "lib", "ImageMagick", "config-Q16")
-            ENV["MAGICK_CODER_MODULE_PATH"] = joinpath("$(imagemagick_prefix)",
+            ENV["MAGICK_CODER_MODULE_PATH"] = joinpath("$(homebrew_prefix)",
                                                        "lib", "ImageMagick", "modules-Q16", "coders")
-            ENV["PATH"] = joinpath("$(imagemagick_prefix)", "bin") * ":" * ENV["PATH"]
+            ENV["PATH"] = joinpath("$(homebrew_prefix)", "bin") * ":" * ENV["PATH"]
 
-            ccall((:MagickWandGenesis,libwand), Void, ())
+            ccall((:MagickWandGenesis, libwand), Void, ())
         end
         """
-    provides(Homebrew.HB, "staticfloat/juliadeps/imagemagick@6", libwand, os = :Darwin,
+    provides(Homebrew.HB, "homebrew/core/imagemagick@6", libwand, os = :Darwin,
              preload = init_fun, onload = "init_deps()")
 end
 

--- a/src/ImageMagick.jl
+++ b/src/ImageMagick.jl
@@ -152,7 +152,7 @@ function image2wand(img, mapi=identity, quality=nothing, permute_horizontal=true
     T = eltype(imgw)
     channelorder = T<:Real ? "Gray" : ColorTypes.colorant_string(T)
     if T <: Union{RGB,RGBA,ARGB,BGRA,ABGR}
-        cs = libversion > v"6.7.5" ? "sRGB" : "RGB"
+        cs = libversion() > v"6.7.5" ? "sRGB" : "RGB"
     else
         cs = channelorder
     end

--- a/src/libmagickwand.jl
+++ b/src/libmagickwand.jl
@@ -30,6 +30,9 @@ end
 
 const have_imagemagick = isdefined(:libwand)
 
+const _libversion = Ref{VersionNumber}()
+libversion() = _libversion[]
+
 # Initialize the library
 function __init__()
     for (key, value) in init_envs
@@ -39,9 +42,8 @@ function __init__()
     ccall((:MagickWandGenesis, libwand), Void, ())
     p = ccall((:MagickQueryConfigureOption, libwand), Ptr{UInt8}, (Ptr{UInt8}, ),
               "LIB_VERSION_NUMBER")
-    global const libversion = VersionNumber(join(split(unsafe_string(p), ',')[1:3], '.'))
+    _libversion[] = VersionNumber(join(split(unsafe_string(p), ',')[1:3], '.'))
 end
-
 
 # Constants
 # Storage types

--- a/src/libmagickwand.jl
+++ b/src/libmagickwand.jl
@@ -35,8 +35,8 @@ const have_imagemagick = isdefined(:libwand)
 
 # Initialize the library
 function __init__()
-    init_deps()
     !have_imagemagick && warn("ImageMagick utilities not found. Install for more file format support.")
+    ccall((:MagickWandGenesis, libwand), Void, ())
 end
 
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,6 @@
 using ImageMagick
 
-info("ImageMagick version ", ImageMagick.libversion)
+info("ImageMagick version ", ImageMagick.libversion())
 
 include("constructed_images.jl")
 include("readremote.jl")


### PR DESCRIPTION
This PR provides a more resilient build process.

- The OSX Homebrew scripts no longer relies on Homebrew.jl's imagemagick@6 prefix. This should prevent issues when Homebrew changes the installed version of imagemagick@6 outside of the ImageMagick.jl build script.
- ImageMagick.libversion is now set during `__init__()` to make sure it always reflects the library's version—even when the library is updated post-build.
- `deps.jl` no longer defines an `init_deps()` function. The initialization of the library is handled in `__init__()`. This function sets the environment variables using the `init_envs` dictionary that is set on-demand during the build process (to allow precompilation), and then calls `ccall((:MagickWandGenesis, libwand), Void, ())`. As far as I can see, the fix in https://github.com/JuliaIO/ImageMagick.jl/pull/91 is no longer necessary with this setup.