### PR TITLE
use a broadcast-round call that works on both 0.5 and 0.6

### DIFF
--- a/test/constructed_images.jl
+++ b/test/constructed_images.jl
@@ -94,11 +94,7 @@ type TestType end
 
     @testset "Colormap usage" begin
         datafloat = reshape(linspace(0.5, 1.5, 6), 2, 3)
-        if VERSION < v"0.6-"
-            dataint = round(UInt8, 254*(datafloat .- 0.5) .+ 1)  # ranges from 1 to 255
-        else
-            dataint = round.(UInt8, 254*(datafloat .- 0.5) .+ 1)  # ranges from 1 to 255
-        end
+        dataint = round.([UInt8], 254*(datafloat .- 0.5) .+ 1)  # ranges from 1 to 255
         # build our colormap
         b = RGB(0,0,1)
         w = RGB(1,1,1)


### PR DESCRIPTION
without depwarns or version conditionals

this change seems totally unrelated to the rest of e8e7870401ae351872cec292e2c7f6041935faaa and really shouldn't have been part of the same commit