### PR TITLE
drop julia 0.5, view keyword arg, and 16-bit tiffs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ os:
   - linux
   - osx
 julia:
-  - 0.5
   - 0.6
   - nightly
 notifications:

--- a/README.md
+++ b/README.md
@@ -32,6 +32,16 @@ further details.
 
 It's worth pointing out that packages such as [Images.jl](https://github.com/JuliaImages/Images.jl) load FileIO for you.
 
+Loading an image is then as simple as
+
+```julia
+img = load(filename[; view=false])
+```
+
+Set `view=true` to reduce memory consumption when loading large files, possibly
+at some slight cost in terms of performance of future operations.
+
+
 # Troubleshooting
 
 ## OSX

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
-julia 0.5
+julia 0.6
 Compat 0.24
 FixedPointNumbers 0.3.0
 ColorTypes 0.2.7

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,5 @@
 environment:
   matrix:
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.5/julia-0.5-latest-win32.exe"
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.5/julia-0.5-latest-win64.exe"
   - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.6/julia-0.6-latest-win32.exe"
   - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.6/julia-0.6-latest-win64.exe"
   - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x86/julia-latest-win32.exe"

--- a/src/ImageMagick.jl
+++ b/src/ImageMagick.jl
@@ -59,7 +59,7 @@ const ufixedtype = Dict(10=>N6f10, 12=>N4f12, 14=>N2f14, 16=>N0f16)
 
 readblob(data::Vector{UInt8}) = load_(data)
 
-function load_(file::Union{AbstractString,IO,Vector{UInt8}}; ImageType=Array, extraprop="", extrapropertynames=nothing)
+function load_(file::Union{AbstractString,IO,Vector{UInt8}}; ImageType=Array, extraprop="", extrapropertynames=nothing, view=false)
     if ImageType != Array
         error("this function now returns an Array, do not use ImageType keyword.")
     end
@@ -119,7 +119,8 @@ function load_(file::Union{AbstractString,IO,Vector{UInt8}}; ImageType=Array, ex
     exportimagepixels!(rawview(channelview(buf)), wand, cs, channelorder)
 
     orient = getimageproperty(wand, "exif:Orientation", false)
-    orientation_dict[orient](buf)
+    oriented_buf = orientation_dict[orient](buf)
+    view ? oriented_buf : collect(oriented_buf)
 end
 
 

--- a/src/ImageMagick.jl
+++ b/src/ImageMagick.jl
@@ -222,6 +222,8 @@ mapIM{T}(c::RGBA{T}) = convert(RGBA{N0f8}, c)
 mapIM{T<:Normed}(c::RGBA{T}) = c
 
 mapIM(x::UInt8) = reinterpret(N0f8, x)
+mapIM(x::UInt16) = reinterpret(N0f16, x)
+mapIM(x::UInt32) = reinterpret(N0f32, x)
 mapIM(x::Bool) = convert(N0f8, x)
 mapIM(x::AbstractFloat) = convert(N0f8, x)
 mapIM(x::Normed) = x

--- a/src/libmagickwand.jl
+++ b/src/libmagickwand.jl
@@ -1,4 +1,4 @@
-import Base: error, size, PermutedDimsArrays
+import Base: error, size
 
 export MagickWand,
     constituteimage,
@@ -196,15 +196,11 @@ for AC in vcat(subtypes(AlphaColor), subtypes(ColorAlpha))
     end
 end
 
-flip1(A)  = flipdim(A, 1)
-flip2(A)  = flipdim(A, 2)
-function flip12(A)
-    inds = Any[indices(A)...]
-    inds[1] = reverse(inds[1])
-    inds[2] = reverse(inds[2])
-    A[inds...]
-end
-pd(A) = permutedims(A, [2;1;3:ndims(A)])
+flip1(A) = view(A, reverse(indices(A,1)), ntuple(x->Colon(),ndims(A)-1)...)
+flip2(A) = view(A, :, reverse(indices(A,2)), ntuple(x->Colon(),ndims(A)-2)...)
+flip12(A) = view(A, reverse(indices(A,1)), reverse(indices(A,2)), ntuple(x->Colon(),ndims(A)-2)...)
+
+pd(A) = PermutedDimsArray(A, [2;1;3:ndims(A)])
 
 const orientation_dict = Dict(nothing => pd,
     "1" => pd,

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,8 +1,3 @@
-ColorTypes
-FixedPointNumbers 0.3.0
 IndirectArrays
-FileIO
-Images
 ZipFile
-Compat
 OffsetArrays

--- a/test/constructed_images.jl
+++ b/test/constructed_images.jl
@@ -153,6 +153,7 @@ type TestType end
         Ar[1] = 0xffff
         A = map(x->Gray(reinterpret(N0f16, x)), Ar)
         fn = joinpath(workdir, "3d16.tif")
+        ImageMagick.save(fn, Ar)
         ImageMagick.save(fn, A)
         B = ImageMagick.load(fn)
 


### PR DESCRIPTION
closes https://github.com/JuliaIO/ImageMagick.jl/issues/102

have `load` return a view instead of using `permutedims`.  note that there are further optimizations to be had here, by writing in-place versions of `flipdim`.

and separately fix saving of 16-bit tiffs.  interestingly, even on master the "binary png" and "alpha" tests are failing.  have not taken the time to `git bisect` when this breakage occurred.