### PR TITLE
Allow for libMagickWand-6.so on FreeBSD

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -114,6 +114,10 @@ if is_apple()
     provides(Homebrew.HB, "homebrew/core/imagemagick@6", libwand, os = :Darwin, preload = preloads)
 end
 
+if Sys.KERNEL === :FreeBSD
+    provides(BSDPkg, "ImageMagick", libwand)
+end
+
 
 @BinDeps.install Dict([(:libwand, :libwand)])
 

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -30,7 +30,7 @@ end
 
 
 libnames    = ["libMagickWand", "CORE_RL_wand_"]
-suffixes    = ["", "-Q16", "-6.Q16", "-Q8"]
+suffixes    = ["", "-Q16", "-6.Q16", "-Q8", "-6"]
 options     = ["", "HDRI"]
 extensions  = ["", ".so.2", ".so.4", ".so.5"]
 aliases     = vec(libnames .*


### PR DESCRIPTION
With this additional suffix, ImageMagick.jl builds on FreeBSD 11.1 STABLE with ImageMagick from the Pkg repository.