### PR TITLE
Change package from imagemagick to libmagick6

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -51,7 +51,7 @@ if is_linux()
     provides(AptGet, "libmagickwand4", libwand)
     provides(AptGet, "libmagickwand5", libwand)
     provides(AptGet, "libmagickwand-6.q16-2", libwand)
-    provides(Pacman, "imagemagick", libwand)
+    provides(Pacman, "libmagick6", libwand)
     provides(Yum, "ImageMagick", libwand)
 end
 


### PR DESCRIPTION
This package requires /usr/lib/libMagickWand-6*.so, which is found in the
libmagick6 package on Arch Linux, not the imagemagick package.  Since
imagemagick has reached version 7, pacman will install libmagick version 7,
which is incompatible with this package.

This fixes #118.