### PR TITLE
add permute_horizontal arg to load()

### DIFF
--- a/src/libmagickwand.jl
+++ b/src/libmagickwand.jl
@@ -97,17 +97,19 @@ flip1(A) = view(A, reverse(axes(A,1)), ntuple(x->Colon(),ndims(A)-1)...)
 flip2(A) = view(A, :, reverse(axes(A,2)), ntuple(x->Colon(),ndims(A)-2)...)
 flip12(A) = view(A, reverse(axes(A,1)), reverse(axes(A,2)), ntuple(x->Colon(),ndims(A)-2)...)
 
-pd(A) = PermutedDimsArray(A, [2;1;3:ndims(A)])
+vertical_major(img::AbstractVector) = img
+vertical_major(A) = PermutedDimsArray(A, [2;1;3:ndims(A)])
 
-const orientation_dict = Dict(nothing => pd,
-    "1" => pd,
-    "2" => A->pd(flip1(A)),
-    "3" => A->pd(flip12(A)),
-    "4" => A->pd(flip2(A)),
-    "5" => identity,
-    "6" => flip2,
-    "7" => flip12,
-    "8" => flip1)
+const orientation_dict = Dict(
+    nothing => (A,ph) -> ph ? vertical_major(A) : identity(A),
+    "1" => (A,ph) -> ph ? vertical_major(A) : identity(A),
+    "2" => (A,ph) -> ph ? vertical_major(flip1(A)) : flip1(A),
+    "3" => (A,ph) -> ph ? vertical_major(flip12(A)) : flip12(A),
+    "4" => (A,ph) -> ph ? vertical_major(flip2(A)) : flip2(A),
+    "5" => (A,ph) -> ph ? identity(A) : vertical_major(A),
+    "6" => (A,ph) -> ph ? flip2(A) : vertical_major(flip2(A)),
+    "7" => (A,ph) -> ph ? flip12(A) : vertical_major(flip12(A)),
+    "8" => (A,ph) -> ph ? flip1(A) : vertical_major(flip1(A)))
 
 function nchannels(imtype::AbstractString, cs::AbstractString, havealpha = false)
     n = 3

--- a/test/constructed_images.jl
+++ b/test/constructed_images.jl
@@ -284,6 +284,28 @@ mutable struct TestType end
         imgr = ImageMagick.load(fn)
         @test imgr == parent(img)
     end
+
+    @testset "permute_horizontal" begin
+        Ar = [0x00 0xff; 0x00 0x00] 
+        A = map(x->Gray(N0f8(x,0)), Ar)
+        fn = joinpath(workdir, "2d.tif")
+
+        ImageMagick.save(fn, A)
+        B = ImageMagick.load(fn)
+        @test A==B
+
+        ImageMagick.save(fn, A, false)
+        B = ImageMagick.load(fn, false)
+        @test A==B
+
+        ImageMagick.save(fn, A, true)
+        B = ImageMagick.load(fn, false)
+        @test A==transpose(B)
+
+        ImageMagick.save(fn, A, false)
+        B = ImageMagick.load(fn, true)
+        @test transpose(A)==B
+    end
 end
 
 nothing


### PR DESCRIPTION
`save` has had it for awhile.  this adds it to `load`.

i've renamed the internal function to `vertical_major` as that is more descriptive.  changing the arg name too would be a breaking change so that would have to wait until a major release.