### PR TITLE
add drone.io CI for ARM

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,0 +1,61 @@
+kind: pipeline
+name: linux-arm-1.0
+
+platform:
+  os: linux
+  arch: arm
+
+steps:
+- name: build
+  image: julia:1.0
+  commands:
+      - uname -a
+      - julia -e 'using Pkg; Pkg.clone(pwd()); Pkg.build("ImageMagick"); Pkg.test("ImageMagick"; coverage=true)'
+
+#---
+#
+#kind: pipeline
+#name: linux-arm-1.1
+#
+#platform:
+#  os: linux
+#  arch: arm
+#
+#steps:
+#- name: build
+#  image: julia:1.1
+#  commands:
+#      - uname -a
+#      - julia -e 'using Pkg; Pkg.clone(pwd()); Pkg.build("ImageMagick"); Pkg.test("ImageMagick"; coverage=true)'
+
+---
+
+kind: pipeline
+name: linux-aarch64-1.0
+
+platform:
+  os: linux
+  arch: arm64
+
+steps:
+- name: build
+  image: julia:1.0
+  commands:
+      - uname -a
+      - julia -e 'using Pkg; Pkg.clone(pwd()); Pkg.build("ImageMagick"); Pkg.test("ImageMagick"; coverage=true)'
+
+---
+
+kind: pipeline
+name: linux-aarch64-1.1
+
+platform:
+  os: linux
+  arch: arm64
+
+steps:
+- name: build
+  image: julia:1.1
+  commands:
+      - uname -a
+      - julia -e 'using Pkg; Pkg.clone(pwd()); Pkg.build("ImageMagick"); Pkg.test("ImageMagick"; coverage=true)'

--- a/.drone.yml
+++ b/.drone.yml
@@ -12,7 +12,7 @@ steps:
       - uname -a
       - julia -e 'using Pkg; Pkg.clone(pwd()); Pkg.build("ImageMagick"); Pkg.test("ImageMagick"; coverage=true)'
 
-#---
+#--- 
 #
 #kind: pipeline
 #name: linux-arm-1.1

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -5,12 +5,13 @@ const verbose = "--verbose" in ARGS
 const prefix = Prefix(get([a for a in ARGS if a != "--verbose"], 1, joinpath(@__DIR__, "usr")))
 
 products = [
-    LibraryProduct(prefix, ["libz"], :libz),
+    LibraryProduct(prefix, String["libz"], :libz),
     LibraryProduct(prefix, String["libjpeg"], :libjpeg),
     LibraryProduct(prefix, String["libpng16"], :libpng),
     LibraryProduct(prefix, String["libtiff"], :libtiff),
     LibraryProduct(prefix, String["libtiffxx"], :libtiffxx),
     LibraryProduct(prefix, String["libMagickWand"], :libwand),
+    LibraryProduct(prefix, String["libm"], :libz),
 ]
 
 version = v"6.9.10-12"

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -11,7 +11,7 @@ products = [
     LibraryProduct(prefix, String["libtiff"], :libtiff),
     LibraryProduct(prefix, String["libtiffxx"], :libtiffxx),
     LibraryProduct(prefix, String["libMagickWand"], :libwand),
-    LibraryProduct(prefix, String["libm"], :libz),
+    LibraryProduct(prefix, String["libopenlibm"], :libm),
 ]
 
 version = v"6.9.10-12"

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -5,13 +5,13 @@ const verbose = "--verbose" in ARGS
 const prefix = Prefix(get([a for a in ARGS if a != "--verbose"], 1, joinpath(@__DIR__, "usr")))
 
 products = [
+    LibraryProduct(prefix, String["libopenlibm"], :libm),
     LibraryProduct(prefix, String["libz"], :libz),
     LibraryProduct(prefix, String["libjpeg"], :libjpeg),
     LibraryProduct(prefix, String["libpng16"], :libpng),
     LibraryProduct(prefix, String["libtiff"], :libtiff),
     LibraryProduct(prefix, String["libtiffxx"], :libtiffxx),
     LibraryProduct(prefix, String["libMagickWand"], :libwand),
-    LibraryProduct(prefix, String["libopenlibm"], :libm),
 ]
 
 version = v"6.9.10-12"

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -15,6 +15,7 @@ products = [
 
 version = v"6.9.10-12"
 dependencies = [
+    "https://github.com/JuliaMath/OpenlibmBuilder/releases/download/v0.6.0/build_Openlibm.v0.6.0.jl",
     "https://github.com/bicycle1885/ZlibBuilder/releases/download/v1.0.4/build_Zlib.v1.2.11.jl",
     "https://github.com/SimonDanisch/LibpngBuilder/releases/download/v1.0.2/build_libpng.v1.6.31.jl",
     "https://github.com/SimonDanisch/LibJPEGBuilder/releases/download/v9b/build_libjpeg.v9.0.0-b.jl",

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,7 +7,9 @@ using Pkg
 function is_ci()
     get(ENV, "TRAVIS", "") == "true" ||
     get(ENV, "APPVEYOR", "") in ("true", "True") ||
-    get(ENV, "CI", "") in ("true", "True")
+    get(ENV, "CI", "") in ("true", "True") ||
+    get(ENV, "DRONE", "") in ("true", "True")
+    
 end
 
 @info "ImageMagick version ", ImageMagick.libversion()


### PR DESCRIPTION
VideoIO is seeing test failures on ARM when comparing VideoIO-read frames to stored png versions, where other platforms aren't. I've tried to find the source of the error in VideoIO, but failed, and just wanted to check that it's not ImageMagick reading the png's incorrectly.