### PR TITLE
Add some precompile statements and clean up the tests

### DIFF
--- a/src/ImageMagick.jl
+++ b/src/ImageMagick.jl
@@ -110,14 +110,14 @@ function _metadata(wand)
     sz, T, cs, channelorder
 end
 
-load(imagefile::File{T}, args...; key_args...) where {T <: DataFormat} = load_(filename(imagefile), args...; key_args...)
-load(filename::AbstractString, args...; key_args...) = load_(filename, args...; key_args...)
-save(imagefile::File{T}, args...; key_args...) where {T <: DataFormat} = save_(filename(imagefile), args...; key_args...)
-save(filename::AbstractString, args...; key_args...) = save_(filename, args...; key_args...)
+load(@nospecialize(imagefile::File{<:DataFormat}), @nospecialize(args...); key_args...) = load_(filename(imagefile), args...; key_args...)
+load(filename::AbstractString, @nospecialize(args...); key_args...) = load_(filename, args...; key_args...)
+save(@nospecialize(imagefile::File{<:DataFormat}), @nospecialize(args...); key_args...) = save_(filename(imagefile), args...; key_args...)
+save(filename::AbstractString, @nospecialize(args...); key_args...) = save_(filename, args...; key_args...)
 
-load(imgstream::Stream{T}, args...; key_args...) where {T <: DataFormat} = load_(stream(imgstream), args...; key_args...)
+load(@nospecialize(imgstream::Stream{<:DataFormat}), @nospecialize(args...); key_args...) = load_(stream(imgstream), args...; key_args...)
 load(imgstream::IO, args...; key_args...) = load_(imgstream, args...; key_args...)
-save(imgstream::Stream{T}, args...; key_args...) where {T <: DataFormat} = save_(imgstream, args...; key_args...)
+save(@nospecialize(imgstream::Stream{<:DataFormat}), args...; key_args...) = save_(imgstream, args...; key_args...)
 
 const ufixedtype = Dict(10=>N6f10, 12=>N4f12, 14=>N2f14, 16=>N0f16)
 
@@ -147,7 +147,7 @@ function load_(file::Union{AbstractString,IO,Vector{UInt8}}, permute_horizontal=
 end
 
 
-function save_(filename::AbstractString, img, permute_horizontal=true; mapi = identity, quality = nothing, kwargs...)
+function save_(filename::AbstractString, @nospecialize(img), permute_horizontal=true; mapi = identity, quality = nothing, kwargs...)
     wand = image2wand(img, mapi, quality, permute_horizontal; kwargs...)
     writeimage(wand, filename)
 end
@@ -160,7 +160,7 @@ function save_(s::Stream, img, permute_horizontal=true; mapi = clamp01nan, quali
     write(stream(s), blob)
 end
 
-function image2wand(img, mapi=identity, quality=nothing, permute_horizontal=true; kwargs...)
+function image2wand(@nospecialize(img), mapi=identity, quality=nothing, permute_horizontal=true; kwargs...)
     local imgw
     try
         imgw = map(x->mapIM(mapi(x)), img)
@@ -268,5 +268,8 @@ function to_explicit(A::AbstractArray)
 end
 to_explicit(A::Array{T}) where {T<:Normed} = rawview(A)
 to_explicit(A::Array{T}) where {T<:AbstractFloat} = to_explicit(convert(Array{N0f8}, A))
+
+include("precompile.jl")
+_precompile_()
 
 end # module

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -1,0 +1,69 @@
+const __bodyfunction__ = Dict{Method,Any}()
+
+# Find keyword "body functions" (the function that contains the body
+# as written by the developer, called after all missing keyword-arguments
+# have been assigned values), in a manner that doesn't depend on
+# gensymmed names.
+# `mnokw` is the method that gets called when you invoke it without
+# supplying any keywords.
+function __lookup_kwbody__(mnokw::Method)
+    function getsym(arg)
+        isa(arg, Symbol) && return arg
+        @assert isa(arg, GlobalRef)
+        return arg.name
+    end
+
+    f = get(__bodyfunction__, mnokw, nothing)
+    if f === nothing
+        fmod = mnokw.module
+        # The lowered code for `mnokw` should look like
+        #   %1 = mkw(kwvalues..., #self#, args...)
+        #        return %1
+        # where `mkw` is the name of the "active" keyword body-function.
+        ast = Base.uncompressed_ast(mnokw)
+        if isa(ast, Core.CodeInfo) && length(ast.code) >= 2
+            callexpr = ast.code[end-1]
+            if isa(callexpr, Expr) && callexpr.head == :call
+                fsym = callexpr.args[1]
+                if isa(fsym, Symbol)
+                    f = getfield(fmod, fsym)
+                elseif isa(fsym, GlobalRef)
+                    if fsym.mod === Core && fsym.name === :_apply
+                        f = getfield(mnokw.module, getsym(callexpr.args[2]))
+                    elseif fsym.mod === Core && fsym.name === :_apply_iterate
+                        f = getfield(mnokw.module, getsym(callexpr.args[3]))
+                    else
+                        f = getfield(fsym.mod, fsym.name)
+                    end
+                else
+                    f = missing
+                end
+            else
+                f = missing
+            end
+        else
+            f = missing
+        end
+        __bodyfunction__[mnokw] = f
+    end
+    return f
+end
+
+function _precompile_()
+    ccall(:jl_generating_output, Cint, ()) == 1 || return nothing
+    precompile(Tuple{typeof(load),File})
+    precompile(Tuple{typeof(load_),String})
+    precompile(Tuple{typeof(save_),String,AbstractArray})
+    precompile(Tuple{typeof(exportimagepixels!),AbstractArray,MagickWand,String,String})
+    precompile(Tuple{typeof(storagetype),Type{UInt8}})
+    for C in (Gray{N0f8}, RGB{N0f8})
+        precompile(Tuple{typeof(default_orientation),Matrix{C},Bool})
+    end
+    precompile(Tuple{typeof(__init__)})
+
+    let fbody = try __lookup_kwbody__(which(load_, (String,Bool,))) catch missing end
+        if !ismissing(fbody)
+            precompile(fbody, (Type,String,Nothing,Bool,typeof(load_),String,Bool,))
+        end
+    end
+end

--- a/test/constructed_images.jl
+++ b/test/constructed_images.jl
@@ -18,12 +18,11 @@ mutable struct TestType end
 
     a = [TestType() TestType()]
     fn = joinpath(workdir, "5by5.png")
-    errfile, io = mktemp()  # suppress warning message
-    redirect_stderr(io) do
+    io = IOBuffer()
+    with_logger(SimpleLogger(io)) do  # suppress warning
         @test_throws MethodError ImageMagick.save(fn, a)
     end
-    close(io)
-    rm(errfile)
+    @test occursin("out-of-range", String(take!(io)))
 
     @testset "Binary png" begin
         a = rand(Bool,5,5)
@@ -120,7 +119,7 @@ mutable struct TestType end
     @testset "Alpha" begin
         c = reinterpret(BGRA{N0f8}, [0xf0884422]'')
         fn = joinpath(workdir, "alpha.png")
-    	ImageMagick.save(fn, c)
+        ImageMagick.save(fn, c)
         C = ImageMagick.load(fn)
         if !ontravis || !Sys.islinux()
             # disabled on Linux Travis because it has a weird copy of
@@ -286,7 +285,7 @@ mutable struct TestType end
     end
 
     @testset "permute_horizontal" begin
-        Ar = [0x00 0xff; 0x00 0x00] 
+        Ar = [0x00 0xff; 0x00 0x00]
         A = map(x->Gray(N0f8(x,0)), Ar)
         fn = joinpath(workdir, "2d.tif")
 
@@ -307,5 +306,3 @@ mutable struct TestType end
         @test transpose(A)==B
     end
 end
-
-nothing

--- a/test/constructed_images.jl
+++ b/test/constructed_images.jl
@@ -3,8 +3,6 @@ using ImageShow       # for show(io, ::MIME, img) & ImageMeta
 using Test
 using ImageCore
 
-ontravis = haskey(ENV, "TRAVIS")
-
 mutable struct TestType end
 
 @testset "IO" begin
@@ -121,24 +119,16 @@ mutable struct TestType end
         fn = joinpath(workdir, "alpha.png")
         ImageMagick.save(fn, c)
         C = ImageMagick.load(fn)
-        if !ontravis || !Sys.islinux()
-            # disabled on Linux Travis because it has a weird copy of
-            # ImageMagick for which this fails (see Images#261)
-            @test C[1] == c[1]
-        end
+        @test C[1] == c[1]
         ImageMagick.save(fn, reinterpret(ARGB32, [0xf0884422]''))
         D = ImageMagick.load(fn)
-        if !ontravis || !Sys.islinux()
-            @test D[1] == c[1]
-        end
+        @test D[1] == c[1]
 
         # Images#396
         c = colorview(RGBA, normedview(permuteddimsview(reshape(0x00:0x11:0xff, 2, 2, 4), (3,1,2))))
         ImageMagick.save(fn, c)
         D = ImageMagick.load(fn)
-        if !ontravis || !Sys.islinux()
-            @test D == c
-        end
+        @test D == c
     end
 
     @testset "3D TIFF (issue #307)" begin
@@ -166,18 +156,16 @@ mutable struct TestType end
         @test A == B
     end
 
-#= FAILS ON SCIENTIFIC LINUX 7.2 WITH IMAGEMAGICK 6.9.5, works for other combos
-    @testset "32-bit TIFF (issue #49)" begin
-        Ar = rand(0x00000000:0xffffffff, 2, 2, 4)
-        Ar[1] = 0xffffffff
-        A = map(x->Gray(reinterpret(N0f32, x)), Ar)
-        fn = joinpath(workdir, "3d32.tif")
-        ImageMagick.save(fn, A)
-        B = ImageMagick.load(fn)
-
-        @test A == B
-    end
-=#
+    # @testset "32-bit TIFF (issue #49)" begin
+    #     Ar = rand(0x00000000:0xffffffff, 2, 2, 4)
+    #     Ar[1] = 0xffffffff
+    #     A = map(x->Gray(reinterpret(N0f32, x)), Ar)
+    #     fn = joinpath(workdir, "3d32.tif")
+    #     ImageMagick.save(fn, A)
+    #     B = ImageMagick.load(fn)
+    #
+    #     @test A == B
+    # end
 
     @testset "Clamping (issue #256)" begin
         Ar = rand(2,2)

--- a/test/readremote.jl
+++ b/test/readremote.jl
@@ -138,7 +138,6 @@ end
             file = getfile("autumn_leaves.png")
             # List properties
             extraProps = magickinfo(file)
-            @show extraProps
 
             img = ImageMagick.load(file)
             @test ImageMagick.metadata(file) == (reverse(size(img)), RGBA{N0f16})
@@ -152,11 +151,11 @@ end
             @test haskey(props, extraProps[1]) == true
             @test props[extraProps[1]] != nothing
 
-            warnfile, io = mktemp()
-            props = redirect_stderr(io) do
+            io = IOBuffer()
+            props = with_logger(SimpleLogger(io)) do
                 magickinfo(file, "Nonexistent property")
             end
-            close(io)
+            @test occursin("Undefined", String(take!(io)))
             @test haskey(props, "Nonexistent property") == true
             @test props["Nonexistent property"] == nothing
         end

--- a/test/readremote.jl
+++ b/test/readremote.jl
@@ -49,15 +49,13 @@ end
         @test m[1] == reverse(size(img))
         @test ndims(img) == 2
         @test eltype(img) in (GrayA{N0f8}, RGBA{N0f8})
-        if Sys.islinux()
-            outname = joinpath(writedir, "wmark_image.png")
-            ImageMagick.save(outname, img)
-            sleep(0.2)
-            imgc = ImageMagick.load(outname)
-            @test img == imgc
-            open(outname, "w") do file
-                show(file, MIME("image/png"), img)
-            end
+        outname = joinpath(writedir, "wmark_image.png")
+        ImageMagick.save(outname, img)
+        sleep(0.2)
+        imgc = ImageMagick.load(outname)
+        @test img == imgc
+        open(outname, "w") do file
+            show(file, MIME("image/png"), img)
         end
         @test reinterpret(UInt32, map(RGB24, img)) ==
             map(x->x&0x00ffffff, reinterpret(UInt32, map(ARGB32, img)))
@@ -74,8 +72,7 @@ end
         ImageMagick.save(outname, img)
         imgc = ImageMagick.load(outname)
         T = eltype(imgc)
-        # Why does this one fail on OSX??
-        Sys.isapple() || @test img == imgc
+        @test img == imgc
         @test reinterpret(UInt32, map(RGB24, img)) ==
             map(x->x&0x00ffffff, reinterpret(UInt32, map(ARGB32, img)))
         imgrgb8 = map(RGB{N0f8}, img)
@@ -93,14 +90,12 @@ end
         @test ndims(img) == 2
         @test eltype(img) == RGBA{N0f16}
         outname = joinpath(writedir, "autumn_leaves.png")
-        Sys.isapple() || begin
-            ImageMagick.save(outname, img)
-            sleep(0.2)
-            imgc = ImageMagick.load(outname)
-            @test img == imgc
-            @test reinterpret(UInt32, map(RGB24, img)) ==
-                map(x->x&0x00ffffff, reinterpret(UInt32, map(ARGB32, img)))
-        end
+        ImageMagick.save(outname, img)
+        sleep(0.2)
+        imgc = ImageMagick.load(outname)
+        @test img == imgc
+        @test reinterpret(UInt32, map(RGB24, img)) ==
+            map(x->x&0x00ffffff, reinterpret(UInt32, map(ARGB32, img)))
         open(outname, "w") do file
             show(file, MIME("image/png"), img)
         end
@@ -122,7 +117,7 @@ end
     @testset "Images with a temporal dimension" begin
         fname = "swirl_video.gif"
         #fname = "bunny_anim.gif"  # this one has transparency but LibMagick gets confused about its size
-        file = getfile(fname)  # this also has transparency
+        file = getfile(fname)
         img = ImageMagick.load(file)
         @test ImageMagick.metadata(file) == (size(img)[[2,1,3]], RGB{N0f8})
         @test size(img, 3) == 26
@@ -134,31 +129,29 @@ end
     end
 
     @testset "Extra properties" begin
-        Sys.isapple() || begin
-            file = getfile("autumn_leaves.png")
-            # List properties
-            extraProps = magickinfo(file)
+        file = getfile("autumn_leaves.png")
+        # List properties
+        extraProps = magickinfo(file)
 
-            img = ImageMagick.load(file)
-            @test ImageMagick.metadata(file) == (reverse(size(img)), RGBA{N0f16})
-            props = magickinfo(file, extraProps)
-            for key in extraProps
-                @test haskey(props, key) == true
-                @test props[key] != nothing
-            end
-
-            props = magickinfo(file, extraProps[1])
-            @test haskey(props, extraProps[1]) == true
-            @test props[extraProps[1]] != nothing
-
-            io = IOBuffer()
-            props = with_logger(SimpleLogger(io)) do
-                magickinfo(file, "Nonexistent property")
-            end
-            @test occursin("Undefined", String(take!(io)))
-            @test haskey(props, "Nonexistent property") == true
-            @test props["Nonexistent property"] == nothing
+        img = ImageMagick.load(file)
+        @test ImageMagick.metadata(file) == (reverse(size(img)), RGBA{N0f16})
+        props = magickinfo(file, extraProps)
+        for key in extraProps
+            @test haskey(props, key) == true
+            @test props[key] != nothing
         end
+
+        props = magickinfo(file, extraProps[1])
+        @test haskey(props, extraProps[1]) == true
+        @test props[extraProps[1]] != nothing
+
+        io = IOBuffer()
+        props = with_logger(SimpleLogger(io)) do
+            magickinfo(file, "Nonexistent property")
+        end
+        @test occursin("Undefined", String(take!(io)))
+        @test haskey(props, "Nonexistent property") == true
+        @test props["Nonexistent property"] == nothing
     end
 end
 
@@ -181,5 +174,3 @@ end
     end
     ZipFile.close(r)
 end
-
-nothing

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,12 +4,6 @@ using Random: bitrand
 using Base.CoreLogging: SimpleLogger, with_logger
 using Pkg
 
-function is_ci()
-    get(ENV, "TRAVIS", "") == "true" ||
-    get(ENV, "APPVEYOR", "") in ("true", "True") ||
-    get(ENV, "CI", "") in ("true", "True")
-end
-
 include("constructed_images.jl")
 include("readremote.jl")
 include("badimages.jl")


### PR DESCRIPTION
Together with https://github.com/JuliaIO/FileIO.jl/pull/243, this shaves about 1s off the first call to `testimage("lighthouse")`.