### PR TITLE
Suppress repetitive 32bit TIFF warnings

### DIFF
--- a/src/ImageMagick.jl
+++ b/src/ImageMagick.jl
@@ -88,7 +88,7 @@ function _metadata(wand)
     elseif depth <= 16
         T = Normed{UInt16,evendepth}
     else
-        @warn "some versions of ImageMagick give spurious low-order bits for 32-bit TIFFs"
+        @warn "some versions of ImageMagick give spurious low-order bits for 32-bit TIFFs" maxlog=1
         T = Normed{UInt32,evendepth}
     end
 


### PR DESCRIPTION
Use *maxlog=1* so that this warning is issued only once per session, otherwise reading array of images results in a warnings flood.