### PR TITLE
Fix "tmp not defined" in exportimagepixels!()

### DIFF
--- a/src/libmagickwand.jl
+++ b/src/libmagickwand.jl
@@ -214,6 +214,7 @@ function exportimagepixels!(@nospecialize(buffer::AbstractArray{<:Union{Unsigned
     cols, rows, nimages = getsize(buffer, channelorder)
     ncolors = colorsize(buffer, channelorder)
     if isa(buffer, Array)
+        tmp = nothing
         p = pointer(buffer)
     else
         tmp = similar(buffer)
@@ -225,7 +226,7 @@ function exportimagepixels!(@nospecialize(buffer::AbstractArray{<:Union{Unsigned
         status == 0 && error(wand)
         p += sizeof(T)*cols*rows*ncolors
     end
-    isa(buffer, Array) || buffer .= tmp
+    isa(buffer, Array) || (buffer .= tmp)
     buffer
 end
 

--- a/src/libmagickwand.jl
+++ b/src/libmagickwand.jl
@@ -209,7 +209,7 @@ bitdepth(buffer::AbstractArray{C}) where {C<:Colorant} = 8*sizeof(eltype(C))
 bitdepth(buffer::AbstractArray{T}) where {T} = 8*sizeof(T)
 
 # colorspace is included for consistency with constituteimage, but it is not used
-function exportimagepixels!(@nospecialize(buffer::AbstractArray{<:Union{Unsigned,Bool}}), wand::MagickWand,  colorspace::String, channelorder::String; x = 0, y = 0)
+function exportimagepixels!(@nospecialize(buffer::AbstractArray{<:Union{Unsigned,Bool}}), wand::MagickWand, colorspace::String, channelorder::String; x = 0, y = 0)
     T = eltype(buffer)
     cols, rows, nimages = getsize(buffer, channelorder)
     ncolors = colorsize(buffer, channelorder)


### PR DESCRIPTION
Probably this typo got exposed because I was calling *exportimagepixels!()` directly.