### PR TITLE
Get bit depth from all images in stack

### DIFF
--- a/src/ImageMagick.jl
+++ b/src/ImageMagick.jl
@@ -81,9 +81,17 @@ function _metadata(wand)
     evendepth = ((depth+1)>>1)<<1
     if depth <= 8
         if cs == "Gray"
-            T = getimagechanneldepth(wand, GrayChannel) == 1 ? Bool : N0f8
+            cdepth = getimagechanneldepth(wand, GrayChannel)
+            if n > 1
+                for k = 1:n  # while it might seem that this should be 2:n, that doesn't work...
+                    nextimage(wand)
+                    cdepth = max(cdepth, getimagechanneldepth(wand, GrayChannel))
+                end
+                resetiterator(wand)
+            end
+            T = cdepth == 1 ? Bool : N0f8
         else
-            T = Normed{UInt8,8}     # otherwise use 8 fractional bits
+            T = N0f8     # otherwise use 8 fractional bits
         end
     elseif depth <= 16
         T = Normed{UInt16,evendepth}


### PR DESCRIPTION
I was sent a 3d image stack where the first image was black. It turned out that the first image was written with 1-bit depth (essentially as a BitArray) but later ones with some nonzero pixels were written with larger bit depths. So we have to check all images before deciding on the channel bit depth.