### PR TITLE
Avoid using the deprecated ColorView type

### DIFF
--- a/src/ImageMagick.jl
+++ b/src/ImageMagick.jl
@@ -270,7 +270,9 @@ mapIM(x::Normed) = x
 to_contiguous(A::Array) = A
 to_contiguous(A::AbstractArray) = collect(A)
 to_contiguous(A::BitArray) = convert(Array{Bool}, A)
-to_contiguous(A::ColorView) = to_contiguous(channelview(A))
+if isdefined(ImageCore, :ColorView)
+    to_contiguous(A::ColorView) = to_contiguous(channelview(A))
+end
 
 to_explicit(A::Array{C}) where {C<:Colorant} = to_explicit(channelview(A))
 function to_explicit(A::AbstractArray)


### PR DESCRIPTION
It's been deprecated a long time, but only as a call, not as a binding.