### PR TITLE
[maintenance] reduce dependencies and update README badge

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -5,6 +5,7 @@ task:
   env:
     matrix:
       - JULIA_VERSION: 1.3
+      - JULIA_VERSION: 1
       - JULIA_VERSION: nightly
   install_script:
     - sh -c "$(fetch https://raw.githubusercontent.com/ararslan/CirrusCI.jl/master/bin/install.sh -o -)"

--- a/Project.toml
+++ b/Project.toml
@@ -7,9 +7,6 @@ FileIO = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"
 ImageCore = "a09fc81d-aa75-5fe9-8630-4744c3626534"
 ImageMagick_jll = "c73af94c-d91f-53ed-93a7-00f77d67a9d7"
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
-Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
-Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
-Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
 [compat]
 FileIO = "1"
@@ -24,10 +21,9 @@ ImageShow = "4e3cecfd-b093-5904-9786-8bbb286a6a31"
 ImageTransformations = "02fcd773-0e25-5acc-982a-7f6622650795"
 IndirectArrays = "9b13fd28-a010-5f03-acff-a1bbcff69959"
 OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
-Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 ZipFile = "a5390f91-8eb1-5f08-bee0-b1d1ffed6cea"
 
 [targets]
-test = ["Downloads", "OffsetArrays", "Pkg", "Test", "Random", "IndirectArrays", "ZipFile", "ImageTransformations", "ImageShow", "ImageMetadata"]
+test = ["Downloads", "OffsetArrays", "Test", "Random", "IndirectArrays", "ZipFile", "ImageTransformations", "ImageShow", "ImageMetadata"]

--- a/Project.toml
+++ b/Project.toml
@@ -18,8 +18,6 @@ ImageMagick_jll = "6.9.10"
 julia = "1.3"
 
 [extras]
-ColorVectorSpace = "c3611d14-8923-5661-9e6a-0046d554d3a4"
-Colors = "5ae59095-9a9b-59fe-a467-6f913c188581"
 Downloads = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
 ImageMetadata = "bc367c6b-8a6b-528e-b4bd-a4b897500b49"
 ImageShow = "4e3cecfd-b093-5904-9786-8bbb286a6a31"
@@ -32,4 +30,4 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 ZipFile = "a5390f91-8eb1-5f08-bee0-b1d1ffed6cea"
 
 [targets]
-test = ["ColorVectorSpace", "Colors", "Downloads", "OffsetArrays", "Pkg", "Test", "Random", "IndirectArrays", "ZipFile", "ImageTransformations", "ImageShow", "ImageMetadata"]
+test = ["Downloads", "OffsetArrays", "Pkg", "Test", "Random", "IndirectArrays", "ZipFile", "ImageTransformations", "ImageShow", "ImageMetadata"]

--- a/README.md
+++ b/README.md
@@ -1,9 +1,11 @@
 # ImageMagick
 
-[![Build Status](https://travis-ci.org/JuliaIO/ImageMagick.jl.svg?branch=master)](https://travis-ci.org/JuliaIO/ImageMagick.jl)
-[![Build status](https://ci.appveyor.com/api/projects/status/hl0j4amikte3pl9c/branch/master?svg=true)](https://ci.appveyor.com/project/SimonDanisch/imagemagick-jl/branch/master)
-[![Coverage Status](https://coveralls.io/repos/JuliaIO/ImageMagick.jl/badge.svg?branch=master&service=github)](https://coveralls.io/github/JuliaIO/ImageMagick.jl?branch=master)
-[![codecov.io](http://codecov.io/github/JuliaIO/ImageMagick.jl/coverage.svg?branch=master)](http://codecov.io/github/JuliaIO/ImageMagick.jl?branch=master)
+| **Platform**                                                               | **Build Status**                                                                                |
+|:-------------------------------------------------------------------------------:|:-----------------------------------------------------------------------------------------------:|
+| Linux & MacOS & Windows | [![Github Action][github-action-img]][github-action-url] |
+| FreeBSD x86 | [![Cirrus][cirrus-img]][cirrus-url] |
+
+[![Codecoverage Status][codecov-img]][codecov-url] [![Coveralls Status][coveralls-img]][coveralls-url]
 
 This package provides a wrapper around
 [ImageMagick](http://www.imagemagick.org/) version 6.  It was split off from
@@ -44,3 +46,15 @@ at some slight cost in terms of performance of future operations.
 ## Advanced usage
 
 The environment variable `MAGICK_THREAD_LIMIT` can be used to throttle multithreading.
+
+[github-action-img]: https://github.com/JuliaIO/ImageMagick.jl/actions/workflows/CI.yml/badge.svg
+[github-action-url]: https://github.com/JuliaIO/ImageMagick.jl/actions/workflows/CI.yml
+
+[cirrus-img]: https://api.cirrus-ci.com/github/JuliaIO/ImageMagick.jl.svg
+[cirrus-url]: https://cirrus-ci.com/github/JuliaIO/ImageMagick.jl
+
+[codecov-img]: https://codecov.io/gh/JuliaIO/ImageMagick.jl/branch/master/graph/badge.svg
+[codecov-url]: https://codecov.io/gh/JuliaIO/ImageMagick.jl
+
+[coveralls-img]: https://coveralls.io/repos/github/JuliaIO/ImageMagick.jl/badge.svg?branch=master
+[coveralls-url]: https://coveralls.io/github/JuliaIO/ImageMagick.jl?branch=master

--- a/src/ImageMagick.jl
+++ b/src/ImageMagick.jl
@@ -3,7 +3,6 @@ module ImageMagick
 using FileIO: DataFormat, @format_str, Stream, File, filename, stream
 using InteractiveUtils: subtypes
 using ImageCore
-using Libdl
 using ImageMagick_jll
 using Base: convert
 

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,7 +1,0 @@
-IndirectArrays
-ZipFile
-OffsetArrays
-ColorVectorSpace
-ImageMetadata
-ImageTransformations
-ImageShow

--- a/test/constructed_images.jl
+++ b/test/constructed_images.jl
@@ -1,7 +1,7 @@
 using ImageMagick, IndirectArrays, FileIO, OffsetArrays, ImageMetadata, ImageTransformations
 using ImageShow       # for show(io, ::MIME, img) & ImageMeta
 using Test
-using ImageCore, ColorVectorSpace
+using ImageCore
 using Random, Base.CoreLogging
 
 mutable struct TestType end

--- a/test/readremote.jl
+++ b/test/readremote.jl
@@ -16,7 +16,7 @@ if !isdir(writedir)
 end
 
 @testset "Read remote" begin
-    urlbase = "http://www.imagemagick.org/Usage/images/"
+    urlbase = "https://legacy.imagemagick.org/Usage/images/"
 
     function getfile(name)
         file = joinpath(workdir, name)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,4 @@
-using ImageMagick, ColorVectorSpace, ImageMetadata, ImageTransformations
+using ImageMagick, ImageMetadata, ImageTransformations
 
 using Random: bitrand
 using Base.CoreLogging: SimpleLogger, with_logger

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,7 +2,6 @@ using ImageMagick, ImageMetadata, ImageTransformations
 
 using Random: bitrand
 using Base.CoreLogging: SimpleLogger, with_logger
-using Pkg
 
 include("constructed_images.jl")
 include("readremote.jl")


### PR DESCRIPTION
- ImageCore v0.9 now includes Colors and ColorVectorSpaces
- `Pkg`, `Libdl` are not required after `ImageMagick_jll`. `Random` is test-only dependency.
- update badges

The 1.3 failure is because some test dependencies (e.g., `ImageMetadata`) are not yet compatible to ImageCore v0.9.