### PR TITLE
compat: hardcode ImageMagick_jll to 6.9.10

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -11,7 +11,7 @@ InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 [compat]
 FileIO = "1"
 ImageCore = "0.8.1, 0.9"
-ImageMagick_jll = "6.9.10"
+ImageMagick_jll = "= 6.9.10"
 julia = "1.3"
 
 [extras]


### PR DESCRIPTION
We might just live with the old 6.9.10 version until #206 is fixed.